### PR TITLE
apply --version to changelog output

### DIFF
--- a/lib/tool_belt/changelog.rb
+++ b/lib/tool_belt/changelog.rb
@@ -22,7 +22,10 @@ module ToolBelt
 
     def generate_entries(issues)
       issues.each do |issue|
-        next unless Redmine::Issue.closed?(issue)
+        redmine_issue = Redmine::Issue.from_raw_data('issue' => issue)
+        next unless redmine_issue.closed?
+        next unless redmine_issue.release_id == config.redmine_release_id
+
         generate_entry(issue)
       end
     end

--- a/lib/tool_belt/redmine/issue.rb
+++ b/lib/tool_belt/redmine/issue.rb
@@ -23,6 +23,10 @@ module Redmine
       @raw_data['issue']['fixed_version']['id'] if @raw_data['issue']['fixed_version']
     end
 
+    def release_id
+      @raw_data['issue']['release']['release']['id']
+    end
+
     def set_version(version_id)
       @raw_data['issue']['fixed_version_id'] = version_id
       self

--- a/lib/tool_belt/redmine/redmine_resource.rb
+++ b/lib/tool_belt/redmine/redmine_resource.rb
@@ -16,7 +16,14 @@ class RedmineResource
     options[:headers] = {'X-Redmine-API-Key' => key} if key
 
     @resource = RestClient::Resource.new(site, options)
-    self.raw_data = get(path, params)
+    self.raw_data = get(path, params) unless path.nil?
+  end
+
+  def self.from_raw_data(raw_data = {})
+    resource = self.new
+    resource.raw_data = raw_data
+
+    resource
   end
 
   def base_path


### PR DESCRIPTION
Specifying --version will only include issues set to that same redmine
release. To generate a complete X.Y changelog, you'd have to run this
command for each Z version.

e.g.

```
./tools.rb changelog --version 3.5.0 configs/katello_35.yaml
./tools.rb changelog --version 3.5.1 configs/katello_35.yaml
./tools.rb changelog --version 3.5.2 configs/katello_35.yaml
```

Default version is the first release (i.e. 3.5.0), which hasn't changed with this PR.