### PR TITLE
Create the release folder

### DIFF
--- a/lib/tool_belt/release_environment.rb
+++ b/lib/tool_belt/release_environment.rb
@@ -14,8 +14,7 @@ module ToolBelt
     def setup(args = {})
       github_username = args.fetch(:github_username, nil)
 
-      Dir.mkdir("repos") unless File.exist?("repos")
-      Dir.mkdir(release_directory) unless File.exist?(release_directory)
+      FileUtils.mkdir_p(release_directory) unless Dir.exist?(release_directory)
 
       Dir.chdir(release_directory) do
         @repos.each do |name, repo|


### PR DESCRIPTION
```
[jturel@strangeways tool_belt]$ ./tools.rb setup-environment ./configs/katello/3.7.yaml                                                                                                           
/home/jturel/code/tool_belt/lib/tool_belt/release_environment.rb:18:in `mkdir': No such file or directory @ dir_s_mkdir - repos/katello/3.7.0 (Errno::ENOENT)                                  
        from /home/jturel/code/tool_belt/lib/tool_belt/release_environment.rb:18:in `setup'                                                                                                       
        from /home/jturel/code/tool_belt/lib/tool_belt/commands/setup_environment_command.rb:12:in `execute'                                                                                       
        from /home/jturel/.gem/ruby/gems/clamp-1.3.0/lib/clamp/command.rb:66:in `run'                                                                         
        from /home/jturel/.gem/ruby/gems/clamp-1.3.0/lib/clamp/subcommand/execution.rb:18:in `execute'
        from /home/jturel/.gem/ruby/gems/clamp-1.3.0/lib/clamp/command.rb:66:in `run'                                                                                     
        from /home/jturel/.gem/ruby/gems/clamp-1.3.0/lib/clamp/command.rb:140:in `run'                                                                                                            
        from ./tools.rb:19:in `<main>'   
```

looks like a PICNIC but ... whatever :)