### PR TITLE
Use puppet5 as an external repo in 1.21

### DIFF
--- a/configs/foreman/1.21.yaml
+++ b/configs/foreman/1.21.yaml
@@ -34,7 +34,7 @@
         foreman-1.21-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - puppetlabs-pc1-rhel-7
+      - puppetlabs-puppet5-rhel-7
       - centos-7-server-updates
       - centos-7-server
   - name: foreman-1.21-rhel7


### PR DESCRIPTION
This mirrors nightly and avoids the EOL puppet version.