### PR TITLE
Use centos-release instead of redhat-release-server

### DIFF
--- a/configs/foreman/nightly.yaml
+++ b/configs/foreman/nightly.yaml
@@ -229,6 +229,7 @@
       build:
         - bash
         - bzip2
+        - centos-release
         - coreutils
         - cpio
         - diffutils
@@ -241,7 +242,6 @@
         - info
         - make
         - patch
-        - redhat-release-server
         - redhat-rpm-config
         - rpm-build
         - sed
@@ -253,7 +253,7 @@
         - xz
       srpm-build:
         - bash
-        - redhat-release-server
+        - centos-release
         - redhat-rpm-config
         - rhpkg-simple
         - rpm-build


### PR DESCRIPTION
In the past we used redhat-release-server because it had the dist tag set to .el7 where centos-release had it set to el7.centos. This changed in centos-release-7-5.

https://bugs.centos.org/view.php?id=14955 has more information.