### PR TITLE
Update Foreman release procedure

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -55,30 +55,18 @@
   * [ ] Tag: `git tag -s -m "Release <%= full_version %>" <%= full_version %>`
   * [ ] Push: `git push --follow-tags`
 * [ ] Run the Jenkins [Tarballs Release](https://ci.theforeman.org/job/tarballs-release/) to create tarballs
-* [ ] Verify tarballs are present on downloads.theforeman.org
-* [ ] Download, sign and upload detached signatures
+* [ ] [Download](https://github.com/ekohl/theforeman-rel-eng/blob/master/download_tarballs), [inspect](https://github.com/ekohl/theforeman-rel-eng/blob/master/inspect_tarballs), [sign and upload detached signatures](https://github.com/ekohl/theforeman-rel-eng/blob/master/sign_tarballs)
 
 Note: If for some reason there was an issue with the tarballs that required uploading new tarballs, CDN cache should be invalidated so that the builders use the updated tarballs.
 
 # Packaging a release
 
-* [ ] In foreman-packaging rpm/<%= short_version %> branch, change foreman.spec, foreman-proxy.spec, foreman-selinux.spec, foreman-installer.spec:
-  * [ ] Set version to `<%= version %>`
-  * [ ] Set prerelease to `<%= extra %>`
-<% unless is_rc %>  * [ ] Reset release to `1`
-<% end %>  * [ ] In each package dir, remove the old tarball, run `spectool -g *.spec` and `git annex add *.tar.bz2`
-  * [ ] Commit with message "Release <%= full_version %>"
-  * [ ] Submit a pull request
-* [ ] Update changelog files for debs:
-  * [ ] `scripts/changelog.rb -v <%= debian_full_version %> -m "<%= full_version %> released" debian/*/*/changelog`
-  * [ ] Submit a pull request
-* [ ] Trigger next step of release pipeline: [release_packages](https://ci.theforeman.org/job/release_packages/)
-* [ ] Use [RPM_Packaging](https://projects.theforeman.org/projects/foreman/wiki/RPM_Packaging) to sign RPMs
-  * [ ] Download RPMs
-  * [ ] Sign RPMs
-  * [ ] Upload signatures
-  * [ ] Upload RPMs
-  * [ ] Sign "extra" RPMs
-* [ ] Trigger [release_mash](https://ci.theforeman.org/job/release_mash/)
-* [ ] Trigger [release_test](https://ci.theforeman.org/job/release_test/) if mashing didn't
-* [ ] Trigger [release_push_deb](https://ci.theforeman.org/job/release_push_deb/) and [release_push_rpm](https://ci.theforeman.org/job/release_push_rpm/) if testing didn't
+[Background documentation](https://projects.theforeman.org/projects/foreman/wiki/Release_Process#Packaging-a-release)
+
+* [ ] Update [foreman-packaging](https://github.com/theforeman/foreman-packaging) [rpm/<%= short_version %>](https://github.com/ekohl/theforeman-rel-eng/blob/master/bump_rpm_packaging) and [deb/<%= short_version %>](https://github.com/ekohl/theforeman-rel-eng/blob/master/bump_deb_packaging) branches
+* [ ] Trigger [release_packages in Jenkins](https://ci.theforeman.org/job/release_packages/) by calling [release_packages](https://github.com/ekohl/theforeman-rel-eng/blob/master/release_packages)
+* [ ] [Download](https://github.com/ekohl/theforeman-rel-eng/blob/master/download_rpms), [sign](https://github.com/ekohl/theforeman-rel-eng/blob/master/sign_rpms), [upload RPM signatures](https://github.com/ekohl/theforeman-rel-eng/blob/master/upload_rpm_signatures) and [upload RPMs](https://github.com/ekohl/theforeman-rel-eng/blob/master/upload_rpms)
+<% if is_rc %>* [ ] [Download](https://github.com/ekohl/theforeman-rel-eng/blob/master/download_extras), [sign](https://github.com/ekohl/theforeman-rel-eng/blob/master/sign_extras) and [upload](https://github.com/ekohl/theforeman-rel-eng/blob/master/upload_extras) "extra" RPMs
+<% end %>* [ ] Trigger [release_mash](https://ci.theforeman.org/job/release_mash/) if it wasn't already
+* [ ] If mashing didn't, trigger [release_test](https://ci.theforeman.org/job/release_test/)
+* [ ] If testing didn't, trigger [release_push_deb](https://ci.theforeman.org/job/release_push_deb/) and [release_push_rpm](https://ci.theforeman.org/job/release_push_rpm/) by calling [promote_staging](https://github.com/ekohl/theforeman-rel-eng/blob/master/promote_staging)


### PR DESCRIPTION
I now have scripts to do these steps so the various indivdual steps are no longer needed.

In practice we only sign "extra" RPMs during the RC stage. Usually only on the first but this is good enough.