### PR TITLE
Move the Foreman nightly build env to Puppet 6

### DIFF
--- a/configs/foreman/nightly.yaml
+++ b/configs/foreman/nightly.yaml
@@ -28,7 +28,7 @@
         foreman-nightly-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - puppetlabs-puppet5-rhel-7
+      - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
   - name: foreman-nightly-rhel7


### PR DESCRIPTION
This will need work to actually create this tag before it's merged. I'm also not sure if we should be building with the latest or the oldest supported version.