### PR TITLE
Move nonscl plugins above scl

### DIFF
--- a/configs/foreman/1.22.yaml
+++ b/configs/foreman/1.22.yaml
@@ -58,6 +58,25 @@
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
+  - name: foreman-plugins-1.22-nonscl-rhel7
+    based_off: foreman-plugins-nightly-nonscl-rhel7
+    helper_tags:
+      foreman-plugins-1.22-nonscl-rhel7-override: null
+    build_target: foreman-plugins-1.22-nonscl-rhel7-build
+    build_package_group_source_tag: foreman-plugins-1.22-nonscl-rhel7-build
+    arches:
+      - x86_64
+    inherits:
+      foreman-plugins-1.22-nonscl-rhel7-build:
+        foreman-plugins-1.22-nonscl-rhel7-override: 0
+        foreman-1.22-rhel7: 15
+        foreman-1.22-nonscl-rhel7: 10
+      foreman-plugins-1.22-nonscl-rhel7-override:
+        foreman-plugins-1.22-nonscl-rhel7: 0
+    external_repos:
+      - epel-7
+      - centos-7-server-updates
+      - centos-7-server
   - name: foreman-plugins-1.22-rhel7
     based_off: foreman-plugins-nightly-rhel7
     helper_tags:
@@ -78,25 +97,6 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
-      - centos-7-server
-  - name: foreman-plugins-1.22-nonscl-rhel7
-    based_off: foreman-plugins-nightly-nonscl-rhel7
-    helper_tags:
-      foreman-plugins-1.22-nonscl-rhel7-override: null
-    build_target: foreman-plugins-1.22-nonscl-rhel7-build
-    build_package_group_source_tag: foreman-plugins-1.22-nonscl-rhel7-build
-    arches:
-      - x86_64
-    inherits:
-      foreman-plugins-1.22-nonscl-rhel7-build:
-        foreman-plugins-1.22-nonscl-rhel7-override: 0
-        foreman-1.22-rhel7: 15
-        foreman-1.22-nonscl-rhel7: 10
-      foreman-plugins-1.22-nonscl-rhel7-override:
-        foreman-plugins-1.22-nonscl-rhel7: 0
-    external_repos:
-      - epel-7
       - centos-7-server-updates
       - centos-7-server
   - name: foreman-1.22-rhel7-dist

--- a/configs/foreman/nightly.yaml
+++ b/configs/foreman/nightly.yaml
@@ -51,6 +51,25 @@
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
+  - name: foreman-plugins-nightly-nonscl-rhel7
+    based_off: null
+    helper_tags:
+      foreman-plugins-nightly-nonscl-rhel7-override: null
+    build_target: foreman-plugins-nightly-nonscl-rhel7-build
+    build_package_group_source_tag: foreman-plugins-nightly-nonscl-rhel7-build
+    arches:
+      - x86_64
+    inherits:
+      foreman-plugins-nightly-nonscl-rhel7-build:
+        foreman-plugins-nightly-nonscl-rhel7-override: 0
+        foreman-nightly-rhel7: 15
+        foreman-nightly-nonscl-rhel7: 10
+      foreman-plugins-nightly-nonscl-rhel7-override:
+        foreman-plugins-nightly-nonscl-rhel7: 0
+    external_repos:
+      - epel-7
+      - centos-7-server-updates
+      - centos-7-server
   - name: foreman-plugins-nightly-rhel7
     based_off: null
     helper_tags:
@@ -71,25 +90,6 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
-      - centos-7-server
-  - name: foreman-plugins-nightly-nonscl-rhel7
-    based_off: null
-    helper_tags:
-      foreman-plugins-nightly-nonscl-rhel7-override: null
-    build_target: foreman-plugins-nightly-nonscl-rhel7-build
-    build_package_group_source_tag: foreman-plugins-nightly-nonscl-rhel7-build
-    arches:
-      - x86_64
-    inherits:
-      foreman-plugins-nightly-nonscl-rhel7-build:
-        foreman-plugins-nightly-nonscl-rhel7-override: 0
-        foreman-nightly-rhel7: 15
-        foreman-nightly-nonscl-rhel7: 10
-      foreman-plugins-nightly-nonscl-rhel7-override:
-        foreman-plugins-nightly-nonscl-rhel7: 0
-    external_repos:
-      - epel-7
       - centos-7-server-updates
       - centos-7-server
   - name: foreman-nightly-rhel7-dist


### PR DESCRIPTION
When running the script to create the right tags, it fails because it tries to mention a tag that doesn't exist yet. By ordering it, it can succeed.