### PR TITLE
Ensure prior releases are reflected in Changelog

### DIFF
--- a/lib/tool_belt/commands/changelog_command.rb
+++ b/lib/tool_belt/commands/changelog_command.rb
@@ -3,11 +3,10 @@ require_relative 'debug_option'
 module ToolBelt
   module Command
     class ChangelogCommand < Clamp::Command
-
       include DebugOption
 
       parameter "config_file", "Release configuration file"
-      option "--version", 'VERSION', "Version to check cherry picks for"
+      option "--version", 'VERSION', "Version to create changelog for"
 
       def execute
         config = ToolBelt::Config.new(config_file, version)
@@ -19,11 +18,10 @@ module ToolBelt
         )
 
         issue_service = IssueService.new(config.options)
-        issues = issue_service.load_issues
+        issues = issue_service.load_issues(with_version_priors: true)
 
         ToolBelt::Changelog.new(config.options, release_environment, issues)
       end
-
     end
   end
 end

--- a/lib/tool_belt/commands/cherry_pick_command.rb
+++ b/lib/tool_belt/commands/cherry_pick_command.rb
@@ -8,7 +8,7 @@ module ToolBelt
         config = ToolBelt::Config.new(config_file, version)
 
         issue_service = ToolBelt::IssueService.new(config.options)
-        issues = issue_service.load_issues(true)
+        issues = issue_service.load_issues(with_all_priors: true)
 
         release_environment = ToolBelt::ReleaseEnvironment.new(config.options.repos, config.options.namespace)
         release_environment.update_repos

--- a/lib/tool_belt/issue_service.rb
+++ b/lib/tool_belt/issue_service.rb
@@ -3,13 +3,14 @@ require File.join(File.dirname(__FILE__), 'redmine/project')
 module ToolBelt
   # Find issues for a particular project & release
   class IssueService
-    attr_accessor :project_name, :release, :redmine_version_id, :prior_releases
+    attr_accessor :project_name, :release, :redmine_version_id, :prior_releases, :version_priors
 
     def initialize(config)
       self.project_name = config.project
       self.release = config.release
       self.redmine_version_id = config.redmine_version_id
       self.prior_releases = config.prior_releases || []
+      self.version_priors = config.releases.dig(:"#{release}", :prior_release) || []
     end
 
     def project
@@ -20,10 +21,19 @@ module ToolBelt
       project.issues_for_version(version_id)
     end
 
-    def load_issues(include_prior=false)
+    def load_issues(with_all_priors: false, with_version_priors: false)
       issues = release_issues(redmine_version_id)
 
-      if include_prior
+      if with_version_priors
+        # when creating a changelog to include only the relevant prior versions
+        version_priors.each do |prior_version|
+          prior = prior_releases[:"#{prior_version}"]
+          fail("Prior version #{prior_version} was not configured for #{release}") unless prior
+
+          issues.concat(release_issues(prior[:redmine_version_id]))
+        end
+      elsif with_all_priors
+        # when cherry-picking to make sure nothing is missed
         prior_releases.each do |_version, meta|
           issues.concat(release_issues(meta[:redmine_version_id]))
         end


### PR DESCRIPTION
This PR fixes this scenario:

> As a dev I've released Katello 3.11.1 and want to release 3.11.2 which includes a new prior version: 3.10.2. Cherry-picking works fine, but generating a 3.11.2 changelog does not indicate the changes that were part of 3.10.2

I've achieved this by allowing the ability to map a prior version (3.10.2) to a version within the release stream(3.11.2):

```
:prior_releases:
  :3.10.2:
    :redmine_version_id: 1037
  :3.10.1:
    :redmine_version_id: 975
  :3.9.2:
    :redmine_version_id: 978
:releases:
  :3.11.2:
    :redmine_version_id: 1038
    :prior_releases:
      - 3.10.2
  :3.11.1:
    :redmine_version_id: 992
  :3.11.0:
:redmine_version_id: 946
```

This works, but I think it'd like to completely omit the top-level `prior_releases` key and have a `prior_releases` key if relevant for each release in the stream - with backward compatibility for the old format, too.

Please test this out and give some feedback on the above comment.