### PR TITLE
Copy dir contents only.

### DIFF
--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -43,7 +43,7 @@
       GITDIR=~/git  #directory containing theforeman.org git repo
 
       FOREMAN_APIPIE_LANGS=en rake apipie:cache
-      cp -rf public/apipie-cache $GITDIR/theforeman.org/plugins/katello/$VERSION/api
+      cp -rf public/apipie-cache/* $GITDIR/theforeman.org/plugins/katello/$VERSION/api
       # clear out json files
       find $GITDIR/theforeman.org/plugins/katello/$VERSION/api -name "*.json" -type f -delete
 


### PR DESCRIPTION
Fixes this command to copy the contents, not the directory itself, into the target.