### PR TITLE
Add GPG keys to pulp configs

### DIFF
--- a/configs/pulp/2.20.yaml
+++ b/configs/pulp/2.20.yaml
@@ -2,6 +2,8 @@
 :project: pulp
 :github_org: pulp
 :nightly: true
+:gpg_key: 2C7E5D9A
+:strict_keys: true
 :tags:
   - name: pulp-2.20-rhel7
     based_off: pulp-nightly-rhel7

--- a/configs/pulp/2.21.yaml
+++ b/configs/pulp/2.21.yaml
@@ -2,6 +2,8 @@
 :project: pulp
 :github_org: pulp
 :nightly: true
+:gpg_key: 2C7E5D9A
+:strict_keys: true
 :tags:
   - name: pulp-2.21-rhel7
     based_off: pulp-nightly-rhel7

--- a/configs/pulp/2.nightly.yaml
+++ b/configs/pulp/2.nightly.yaml
@@ -2,6 +2,8 @@
 :project: pulp
 :github_org: pulp
 :nightly: true
+:gpg_key: 2C7E5D9A
+:strict_keys: false
 :tags:
   - name: pulp-nightly-rhel7
     build_target: pulp-nightly-rhel7-build


### PR DESCRIPTION
There have been multiple occasions where a Pulp release was pushed but not signed. To mitigate this the pulp mash configs on koji have been updated to enforce strict keys but this hasn't been reflected in the configs until now.