### PR TITLE
Fix RPM instructions

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -80,7 +80,9 @@
   * [ ] [foreman-selinux](https://github.com/theforeman/foreman-selinux)
   * [ ] [smart-proxy](https://github.com/theforeman/smart-proxy)
 * [ ] Update foreman-packaging to <%= develop %>:
-  * [ ] rpm/develop: `sed -i 's/fm<%= release.tr('.', '_') %>/fm<%= develop.tr('.', '_') %>/g' rel-eng/{releasers.conf,tito.props} && obal update --version <%= develop %>.0 --release 1 --prerelease develop --changelog '- Bump version to <%= develop %>-develop' foreman{,-{installer,proxy,release,selinux}}`
+  * [ ] rpm/develop:
+    * [ ] Update the build tag: `sed -i 's/fm<%= release.tr('.', '_') %>/fm<%= develop.tr('.', '_') %>/g' rel-eng/{releasers.conf,tito.props}`
+    * [ ] Set to version `<%= develop %>.0`, reset release to `1` in `packages/foreman/foreman{,-{installer,proxy,release,selinux}}/*.spec` and create a changelog using `obal changelog --message '- Bump version to <%= develop %>-develop' foreman{,-{installer,proxy,release,selinux}}`
   * [ ] deb/develop: `scripts/changelog.rb -v <%= develop %>.0-1 -m "Bump changelog to <%= develop %>.0 to match VERSION" debian/*/*/changelog`
 
 # Other systems


### PR DESCRIPTION
0a955d04273dc2d97b5c8b53ff0fa158e1264cb1 changed this, but it doesn't work because obal can't handle packages without sources. This causes the fetch to break and the command quits after the first package.