### PR TITLE
Skip features heading if empty

### DIFF
--- a/lib/tool_belt/changelog.rb
+++ b/lib/tool_belt/changelog.rb
@@ -64,21 +64,26 @@ module ToolBelt
     end
 
     def format_entries
-      entry_string = "\n## Features\n"
-      @features.each do |category, entries|
-        if category != 'Other'
-          entry_string += "\n### #{category}\n"
+      entry_string = ''
 
-          entries.each do |entry|
-            entry_string += "#{entry}\n"
+      unless @features.empty?
+        entry_string += "\n## Features\n"
+
+        @features.each do |category, entries|
+          if category != 'Other'
+            entry_string += "\n### #{category}\n"
+
+            entries.each do |entry|
+              entry_string += "#{entry}\n"
+            end
           end
         end
-      end
 
-      if @features.key?('Other')
-        entry_string += "\n### Other\n"
-        @features['Other'].each do |entry|
-          entry_string += "#{entry}\n"
+        if @features.key?('Other')
+          entry_string += "\n### Other\n"
+          @features['Other'].each do |entry|
+            entry_string += "#{entry}\n"
+          end
         end
       end
 

--- a/test/changelog_test.rb
+++ b/test/changelog_test.rb
@@ -3,7 +3,7 @@ require 'minitest/mock'
 require 'tool_belt'
 require 'mocha/minitest'
 
-class FormatEntriesTest < MiniTest::Test
+class ChangelogTest < MiniTest::Test
 
   def setup
     issue = Redmine::Issue.new

--- a/test/format_entries_test.rb
+++ b/test/format_entries_test.rb
@@ -1,0 +1,49 @@
+require 'minitest/autorun'
+require 'minitest/mock'
+require 'tool_belt'
+require 'mocha/minitest'
+
+class FormatEntriesTest < MiniTest::Test
+
+  def setup
+    issue = Redmine::Issue.new
+    issue.raw_data = {
+      'issue' => {
+        'status' => {
+          'name'=> 'Closed'
+        },
+        'tracker' => {
+          'name' => "Feature"
+        }
+      }
+    }
+
+    @issues = [
+      issue
+      ]
+
+    @config = mock('release')
+    @config.stubs(:release).returns('v1.0')
+    @config.stubs(:code_name).returns('atest')
+
+    @env = mock('release_environment')
+    @env.stubs(:main_repo).returns('arepo')
+    @env.stubs(:repo_location).returns('someurl')
+
+    ToolBelt::Changelog.any_instance.stubs(:write_changelog)
+  end
+
+  def test_generates_features_heading_when_features_are_not_empty
+    changelog = ToolBelt::Changelog.new(@config, @env, @issues)
+    entries_string = changelog.format_entries
+
+    assert entries_string.include? "Features"
+  end
+
+  def test_skips_features_heading_when_features_is_empty
+    changelog = ToolBelt::Changelog.new(@config, @env, [])
+    entries_string = changelog.format_entries
+
+    refute entries_string.include? "Features"
+  end
+end


### PR DESCRIPTION
This PR introduces a check for empty feature sets in a changelog command. If so, then the featueres heading is skipped.