### PR TITLE
Add deprecation warning scan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'minitest'
 gem 'mocha'
 gem 'octokit'
 gem 'git'
+gem 'parser'
 
 group :development do
   gem 'byebug'

--- a/lib/tool_belt/colors.rb
+++ b/lib/tool_belt/colors.rb
@@ -1,0 +1,19 @@
+class ::String
+  def red
+    colorize(31)
+  end
+
+  def green
+    colorize(32)
+  end
+
+  def yellow
+    colorize(33)
+  end
+
+  private
+
+  def colorize(color_code)
+    "\e[#{color_code}m#{self}\e[0m"
+  end
+end

--- a/lib/tool_belt/commands/check_deprecation_warnings.rb
+++ b/lib/tool_belt/commands/check_deprecation_warnings.rb
@@ -1,0 +1,64 @@
+module ToolBelt
+  module Command
+    class CheckDeprecationWarningsCommand < Clamp::Command
+      parameter 'repo_path', 'Path (relative to tool_belt) of repository to check'
+      option '--version', 'VERSION', 'Release version to check for in x.y format', required: true
+      option '--paths', 'PATHS',
+             'Patterns within the repository to search, separated by a comma.',
+             default: 'app/**/*.rb,lib/**/*.rb'
+
+      def execute
+        root_path = File.expand_path("../../../../#{repo_path}", __FILE__)
+        globs_to_scan = paths.split(',').map { |path| File.expand_path(path, root_path) }
+        puts "\nScanning for deprecation warnings in #{globs_to_scan.join(', ')}\n\n"
+        paths_to_scan = Dir.glob(globs_to_scan)
+
+        finder = ToolBelt::OutdatedDeprecationWarningFinder.new(paths_to_scan, version)
+        finder.scan_for_deprecations
+        current_outdated = finder.deprecations.select { |dep| dep[:outdated] == true }
+        next_outdated = finder.deprecations.select { |dep| dep[:outdated_next_version] == true }
+
+        if current_outdated.any?
+          puts current_outdated_found
+          current_outdated.each { |outdated_dep| puts current_outdated_message(outdated_dep, finder.current_version) }
+        else
+          puts "No currently outdated deprecation warnings found!\n".green
+        end
+
+        if next_outdated.any?
+          puts next_outdated_found(finder.next_minor_version)
+          next_outdated.each { |outdated_dep| puts next_outdated_message(outdated_dep, finder.next_minor_version) }
+        else
+          puts "No deprecation warnings found that will be outdated in the next version!\n".green
+        end
+      end
+
+      private
+
+      def current_outdated_found
+        'Deprecation warnings were found with versions that are outdated, please check below and ' \
+        'ensure both the deprecated functionality and the deprecation warning are removed if ' \
+        "the deprecation is outdated in this release\n".red
+      end
+
+      def next_outdated_found(version)
+        "Deprecation warnings were found marked for removal for the *next* release version #{version}. " \
+        "Please check below and file issues aligned to #{version} to remove the functionality and the " \
+        'deprecation warning. This will ensure the functionality is removed in time for the next ' \
+        "release #{version}. The deprecation warning should stay in this release, only file issues for " \
+        "its removal at this time.\n".yellow
+      end
+
+      def current_outdated_message(outdated_dep, version)
+        "Deprecation warning at #{outdated_dep[:file]} line #{outdated_dep[:line]} is marked for " \
+        "removal in version #{outdated_dep[:version]}, which is less than or equal to the specified " \
+        "version of #{version}.\n\n"
+      end
+
+      def next_outdated_message(outdated_dep, _version)
+        "Deprecation warning at #{outdated_dep[:file]} line #{outdated_dep[:line]} is marked for " \
+        "removal in version #{outdated_dep[:version]}, which is the *next* release version.\n\n"
+      end
+    end
+  end
+end

--- a/lib/tool_belt/deprecation_warning_parser.rb
+++ b/lib/tool_belt/deprecation_warning_parser.rb
@@ -2,7 +2,7 @@ require 'parser/current'
 
 module ToolBelt
   class DeprecationWarningParser < ::Parser::AST::Processor
-    attr_accessor :versions_found
+    attr_reader :versions_found
 
     def initialize(file)
       super()

--- a/lib/tool_belt/deprecation_warning_parser.rb
+++ b/lib/tool_belt/deprecation_warning_parser.rb
@@ -1,0 +1,38 @@
+require 'parser/current'
+
+module ToolBelt
+  class DeprecationWarningParser < ::Parser::AST::Processor
+    attr_accessor :versions_found
+
+    def initialize(file)
+      super()
+      @file = file
+      @versions_found = []
+    end
+
+    def on_begin(node)
+      node.children.each { |c| process(c) }
+    end
+
+    def on_send(node)
+      method_class, method_name, *args = node.children
+      version_regex = /\d+\.\d+/
+
+      if %i[api_deprecation_warning deprecation_warning].include?(method_name)
+        *method_classes = method_class.children if method_class&.children
+        if method_classes.include?(:Deprecation)
+          args.select! { |arg| arg.to_s =~ version_regex }
+          if args.any?
+            found_version = args.first.children.first
+            extracted_version = found_version.scan(version_regex).first
+            @versions_found << {
+              version: extracted_version,
+              file: @file,
+              line: node.loc.line
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tool_belt/outdated_deprecation_warning_finder.rb
+++ b/lib/tool_belt/outdated_deprecation_warning_finder.rb
@@ -1,0 +1,61 @@
+module ToolBelt
+  class OutdatedDeprecationWarningFinder
+    attr_accessor :deprecations
+    attr_accessor :current_version
+    attr_accessor :next_minor_version
+
+    def initialize(paths, version)
+      @paths = paths
+      @version = version
+      @deprecations = []
+      error_if_empty(paths)
+    end
+
+    def scan_for_deprecations
+      outdated_deprecations = []
+
+      @paths.select do |file|
+        ast = ::Parser::CurrentRuby.parse(File.read(file))
+        processor = ToolBelt::DeprecationWarningParser.new(file)
+        processor.process(ast)
+
+        next unless processor.versions_found.any?
+
+        processor.versions_found.each do |version_found|
+          if Gem::Version.new(version_found[:version]) <= current_version
+            version_found[:outdated] = true
+            @deprecations << version_found
+          elsif Gem::Version.new(version_found[:version]) == next_minor_version
+            version_found[:outdated_next_version] = true
+            @deprecations << version_found
+          end
+        end
+      end
+    end
+
+    def next_minor_version
+      bump_minor_version(current_version)
+    end
+
+    def current_version
+      Gem::Version.new(@version)
+    end
+
+    private
+
+    def error_if_empty(paths_to_scan)
+      if paths_to_scan.empty?
+        raise "Couldn't find any files! Please check the path and try again"
+      end
+    rescue RuntimeError => e
+      puts e.message.red
+      exit 1
+    end
+
+    def bump_minor_version(version)
+      version_segments = version.segments
+      version_segments[1] += 1
+      Gem::Version.new(version_segments.join('.'))
+    end
+  end
+end

--- a/lib/tool_belt/outdated_deprecation_warning_finder.rb
+++ b/lib/tool_belt/outdated_deprecation_warning_finder.rb
@@ -1,19 +1,16 @@
 module ToolBelt
   class OutdatedDeprecationWarningFinder
     attr_accessor :deprecations
-    attr_accessor :current_version
-    attr_accessor :next_minor_version
 
     def initialize(paths, version)
       @paths = paths
       @version = version
       @deprecations = []
       error_if_empty(paths)
+      scan_for_deprecations
     end
 
     def scan_for_deprecations
-      outdated_deprecations = []
-
       @paths.select do |file|
         ast = ::Parser::CurrentRuby.parse(File.read(file))
         processor = ToolBelt::DeprecationWarningParser.new(file)
@@ -55,7 +52,7 @@ module ToolBelt
     def bump_minor_version(version)
       version_segments = version.segments
       version_segments[1] += 1
-      Gem::Version.new(version_segments.join('.'))
+      Gem::Version.new(version_segments[0, 2].join('.'))
     end
   end
 end

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -9,6 +9,7 @@
   - [ ] `./tools.rb setup-environment configs/katello/<%= short_version %>.yaml`
   - [ ] `./tools.rb cherry-picks --version <%= full_version %> configs/katello/<%= short_version %>.yaml`
   - [ ] Verify tickets in the cherry_picks_<%= full_version %> file are accounted for or additional cherry pick them
+  - [ ] Check for outdated deprecation warnings in the current and next release with `./tools check-deprecation-warnings --version <%= short_version %> repos/katello/<%= full_version %>/katello`. Follow the instructions in the output of the command.
 
 - [ ] In katello release branch:
   - [ ] Update `lib/katello/version.rb` to <%= full_version %>

--- a/tools.rb
+++ b/tools.rb
@@ -15,6 +15,7 @@ class MainCommand < Clamp::Command
   subcommand "pulp-repo-update", "Update Katello's Pulp repository based on parameters", ToolBelt::Command::PulpRepositoryUpdateCommand
   subcommand "koji", "Commands for various Koji release related tasks", ToolBelt::Command::KojiCommand
   subcommand "mash-scripts", "Generate mash script files for a release", ToolBelt::Command::MashScriptsCommand
+  subcommand "check-deprecation-warnings", "Check codebase for outdated deprecation warnings", ToolBelt::Command::CheckDeprecationWarningsCommand
 end
 
 MainCommand.run


### PR DESCRIPTION
There is a related discussion here:
https://community.theforeman.org/t/deprecation-warnings-how-to-handle-better/17233/9

We will often forget to remove deprecation warnings in the release we say we will. This commit adds the parser gem and a class inheriting from ::Parser::AST::Processor which will scan for deprecation warning methods and any versions in the arguments. It will compare them with the passed in version and print any outdated deprecation locations.