### PR TITLE
check_deprecation_warnings: improve error message

### DIFF
--- a/lib/tool_belt/commands/check_deprecation_warnings.rb
+++ b/lib/tool_belt/commands/check_deprecation_warnings.rb
@@ -10,7 +10,9 @@ module ToolBelt
         config = ToolBelt::Config.new(config_file)
         options = config.options
         repo_path = "repos/#{options.namespace}/#{options.project}/"
-        raise "Repo path #{repo_path} not found!" unless File.exist?(repo_path)
+        unless File.exist?(repo_path)
+          raise "Repo path #{repo_path} not found! Did you forget to run './tools.rb setup-environment #{config_file}' ?"
+        end
 
         globs_to_scan = paths.split(',').map { |path| File.expand_path(path, repo_path) }
         paths_to_scan = Dir.glob(globs_to_scan)

--- a/lib/tool_belt/deprecation_warning_parser.rb
+++ b/lib/tool_belt/deprecation_warning_parser.rb
@@ -24,7 +24,7 @@ module ToolBelt
           args.select! { |arg| arg.to_s =~ version_regex }
           if args.any?
             found_version = args.first.children.first
-            extracted_version = found_version.scan(version_regex).first
+            extracted_version = found_version.to_s.scan(version_regex).first
             @versions_found << {
               version: extracted_version,
               file: @file,


### PR DESCRIPTION
Addresses a couple issues I had running `check_deprecation_warnings` locally:

* Improves error messaging if it can't find the repo path.
* Fixes a small bug where it was trying to run a regex `.scan` on something that was expected to be a String, but was not.