### PR TITLE
Update external repos to reflect current state

### DIFF
--- a/configs/foreman/nightly.yaml
+++ b/configs/foreman/nightly.yaml
@@ -141,8 +141,8 @@
       foreman-nightly-el8-override:
         foreman-nightly-el8: 0
     external_repos:
-      - centos8-baseos
-      - centos8-appstream
+      - test-flat-el8
+      - centos8-devel
       - puppetlabs-puppet6-rhel-8
     build_groups:
       build:

--- a/configs/katello/nightly.yaml
+++ b/configs/katello/nightly.yaml
@@ -119,6 +119,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
+      - epel-7
     build_groups:
       build:
         - bash
@@ -173,6 +174,7 @@
       - centos8-baseos
       - centos8-appstream
       - centos8-powertools
+      - centos8-devel
     build_groups:
       build:
         - bash


### PR DESCRIPTION
Some changes that were done to unblock el8 building weren't persisted to tool-belt.

This is updating toolbelt with current koji external repos