### PR TITLE
Update h-c-k and k-h-t versions for 3.16 RC2

### DIFF
--- a/configs/katello/3.16.yaml
+++ b/configs/katello/3.16.yaml
@@ -23,10 +23,10 @@
     :branch: rpm/2.1
     :repo: https://github.com/theforeman/foreman-packaging.git
   :hammer-cli-katello:
-    :branch: 0.22.0
+    :branch: 0.22.1
     :repo: https://github.com/Katello/hammer-cli-katello.git
   :katello-host-tools:
-    :branch: 3.5.3
+    :branch: 3.5.4
     :repo: https://github.com/Katello/katello-host-tools.git
 :ignores:
   - 28719 # Closed


### PR DESCRIPTION
Updates the hammer-cli-katello and katello-host-tools versions in preparation for Katello 3.16 RC2