### PR TITLE
Add concrete dates to procedures

### DIFF
--- a/lib/tool_belt/commands/procedure.rb
+++ b/lib/tool_belt/commands/procedure.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module ToolBelt
   module Command
     class ProcedureCommand < Clamp::Command
@@ -7,11 +9,17 @@ module ToolBelt
           raise ArgumentError.new('Release must be in major.minor, like 1.20') unless value =~ /^\d+\.\d+$/
           value
         end
+        parameter "target-date", "Target date that the procedure should be completed on"
 
         def execute
+          parsed_date = Date.parse(target_date)
+
           context = {
             release: release,
             develop: bump_last(release),
+            target_date: parsed_date,
+            two_weeks_before: parsed_date - 14,
+            one_week_before: parsed_date - 7,
           }
 
           render(project, 'branch', context)
@@ -24,11 +32,15 @@ module ToolBelt
           raise ArgumentError.new('Release must be in major.minor.patch or major.minor.patch-rcx, like 1.20.0 or 1.20.0-rc1') unless value =~ /^\d+\.\d+\.\d+(-rc\d+)?$/
           value
         end
+        parameter "target-date", "Target date that the procedure should be completed on"
 
         def execute
           version, extra = full_version.split('-', 2)
           major, minor, _ = version.split('.', 3)
           debian_full_version = version + (extra ? "~#{extra.downcase}" : '') + '-1'
+
+          parsed_date = Date.parse(target_date)
+
           context = {
             is_rc: !extra.nil?,
             extra: extra,
@@ -36,6 +48,9 @@ module ToolBelt
             debian_full_version: debian_full_version, # 1.20.0~rc1-1
             full_version: full_version, # 1.20.0-rc1
             version: version, # 1.20.0
+            target_date: parsed_date,
+            two_weeks_before: parsed_date - 14,
+            one_week_before: parsed_date - 7,
           }
 
           render(project, 'release', context)

--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -1,6 +1,6 @@
 [ ] Make this post a wiki
 
-# Two weeks before branching
+# Prep Week: <%= two_weeks_before %> to <%= two_weeks_before + 4 %>
 
 ## Installer Maintainer
 
@@ -32,7 +32,7 @@
   - [ ] Announce string freeze date on discourse and send announcement via https://www.transifex.com/foreman/foreman/announcements/
   - [ ] Update [foreman-dev](https://community.theforeman.org/c/development) with [translations status](https://www.transifex.com/projects/p/foreman/) to encourage 100% translations before release
 
-# During the week before branching
+# Stabilization Week: <%= one_week_before %> to <%= one_week_before + 4 %>
 
 ## Release Owner
 
@@ -76,7 +76,7 @@
 - [ ] Open PR to remove any jobs that are related to end of life versions
 - [ ] Open PR to add <%= release %> to [Forklift versions config](https://github.com/theforeman/forklift/blob/master/vagrant/config/versions.yaml). Once the PR is merged, upgrade pipelines will fail, so do not merge it before packaging has been branched.
 
-# Branching
+# Branching: <%= target_date %>
 
 ## Release Engineer
 
@@ -110,7 +110,7 @@ The next step should only be done after all branching, including packaging, has 
   - [ ] [hammer-cli](https://github.com/theforeman/hammer-cli)
   - [ ] [hammer-cli-foreman](https://github.com/theforeman/hammer-cli-foreman)
 
-# Preparing build systems
+# Preparing build systems: <%= target_date %>
 
 ## Release engineer
 
@@ -123,7 +123,7 @@ The next step should only be done after all branching, including packaging, has 
   - [ ] foreman-packaging's rpm/<%= release %>
     - [ ] Update `packages/foreman/foreman-release/foreman.gpg`, `mock/*.cfg`, `package_manifest.yaml`, `rel-eng/{releasers.conf,tito.props}` and `repoclosure/*.conf`
 
-# Other systems
+# Other systems: <%= target_date %>
 
 ## Release Owner
 

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -1,6 +1,6 @@
 [ ] Make this post a wiki
 
-# Manual updates
+# Manual updates: <%= target_date %>
 
 - [ ] Update manual if applicable for any additional installation steps
 - Update [release notes section](gh-pages/_includes/manuals/<%= short_version %>/1.2_release_notes.md) in the manual:
@@ -15,7 +15,7 @@
 - [ ] [Update](https://github.com/theforeman/theforeman.org#updating-api-auto-generated-docs-by-apipie) the apipie doc and place it in the api/<%= short_version %> directory if any changes were made to the API
 <% end %>
 
-# Preparing code
+# Preparing code: <%= target_date %>
 
 - [ ] Make patch releases of installer modules that have important changes
   - [ ] Branch to MAJ.MIN-stable if recent changes to the module aren't suitable for patch (x.y.z) release
@@ -25,7 +25,7 @@
 <% unless is_rc %>- [ ] Change Redmine version <%= full_version %> state to Closed
 <% end %>
 
-# Tagging a release
+# Tagging a release: <%= target_date %>
 
 - In foreman <%= short_version %>-stable:
   - [ ] Make sure [test_<%= short_version.tr('.', '_') %>_stable](https://ci.theforeman.org/job/test_<%= short_version.tr('.', '_') %>_stable/) is green
@@ -47,7 +47,7 @@
 
 Note: If for some reason there was an issue with the tarballs that required uploading new tarballs, CDN cache should be invalidated so that the builders use the updated tarballs.
 
-# Packaging a release
+# Packaging a release: <%= target_date %>
 
 [Background documentation](https://projects.theforeman.org/projects/foreman/wiki/Release_Process#Packaging-a-release)
 


### PR DESCRIPTION
Adds concrete dates to parts of the tasks, e.g. This mostly works if we always target the same day of the week as the target date, e.g Monday or could adjust for Tuesday. The dates can always be adjusted by hand since this a template.

```
bundle exec ./tools.rb procedure branch foreman 2.2 2020-8-10
```