### PR TITLE
use correct 8 chars from the 3.9 key

### DIFF
--- a/configs/pulpcore/3.9.yaml
+++ b/configs/pulpcore/3.9.yaml
@@ -10,7 +10,7 @@
   - pulpcore-3.9-el7
   - pulpcore-3.9-el8
 :strict_keys: true
-:gpg_key: 3599352A
+:gpg_key: F1502FE9
 :tags:
   - name: pulpcore-3.9-el7
     based_off: pulpcore-3.8-el7

--- a/mash_scripts/pulpcore/3.9/pulpcore-3.9-el7.mash
+++ b/mash_scripts/pulpcore/3.9/pulpcore-3.9-el7.mash
@@ -8,5 +8,5 @@ multilib_method = devel
 tag = pulpcore-3.9-el7
 inherit = True
 strict_keys = True
-keys = 3599352A
+keys = F1502FE9
 arches = x86_64

--- a/mash_scripts/pulpcore/3.9/pulpcore-3.9-el8.mash
+++ b/mash_scripts/pulpcore/3.9/pulpcore-3.9-el8.mash
@@ -8,5 +8,5 @@ multilib_method = devel
 tag = pulpcore-3.9-el8
 inherit = True
 strict_keys = True
-keys = 3599352A
+keys = F1502FE9
 arches = x86_64


### PR DESCRIPTION
gpg needs the last 8, not the first 8…