### PR TITLE
Switch to using epel7 instead of epel-7

### DIFF
--- a/configs/foreman/1.18.yaml
+++ b/configs/foreman/1.18.yaml
@@ -65,7 +65,7 @@
       foreman-1.18-nonscl-rhel7-override:
         foreman-1.18-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-pc1-rhel-7
       - centos-7-server
       - rhel-7.0-server
@@ -85,7 +85,7 @@
       foreman-1.18-rhel7-override:
         foreman-1.18-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - centos-7-server
@@ -108,7 +108,7 @@
       foreman-plugins-1.18-nonscl-rhel7-override:
         foreman-plugins-1.18-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server
       - rhel-7.0-server
       - rhel-7.0-server-optional
@@ -143,7 +143,7 @@
       foreman-plugins-1.18-rhel7-override:
         foreman-plugins-1.18-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - centos-7-server

--- a/configs/foreman/1.19.yaml
+++ b/configs/foreman/1.19.yaml
@@ -64,7 +64,7 @@
       foreman-1.19-nonscl-rhel7-override:
         foreman-1.19-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-pc1-rhel-7
       - centos-7-server
       - rhel-7.0-server
@@ -84,7 +84,7 @@
       foreman-1.19-rhel7-override:
         foreman-1.19-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - centos-7-server
@@ -107,7 +107,7 @@
       foreman-plugins-1.19-nonscl-rhel7-override:
         foreman-plugins-1.19-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server
       - rhel-7.0-server
   - name: foreman-1.19-rhel7-dist
@@ -141,7 +141,7 @@
       foreman-plugins-1.19-rhel7-override:
         foreman-plugins-1.19-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - centos-7-server

--- a/configs/foreman/1.20.yaml
+++ b/configs/foreman/1.20.yaml
@@ -35,7 +35,7 @@
       foreman-1.20-nonscl-rhel7-override:
         foreman-1.20-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-pc1-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -55,7 +55,7 @@
       foreman-1.20-rhel7-override:
         foreman-1.20-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -75,7 +75,7 @@
       foreman-plugins-1.20-nonscl-rhel7-override:
         foreman-plugins-1.20-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
       - rhel-7.0-server-optional
@@ -97,7 +97,7 @@
       foreman-plugins-1.20-rhel7-override:
         foreman-plugins-1.20-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -233,7 +233,7 @@
     external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/1.21.yaml
+++ b/configs/foreman/1.21.yaml
@@ -35,7 +35,7 @@
       foreman-1.21-nonscl-rhel7-override:
         foreman-1.21-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet5-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -55,7 +55,7 @@
       foreman-1.21-rhel7-override:
         foreman-1.21-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -75,7 +75,7 @@
       foreman-plugins-1.21-nonscl-rhel7-override:
         foreman-plugins-1.21-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
   - name: foreman-plugins-1.21-rhel7
@@ -96,7 +96,7 @@
       foreman-plugins-1.21-rhel7-override:
         foreman-plugins-1.21-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -230,7 +230,7 @@
         foreman-client-1.21-rhel7: 0
       foreman-client-1.21-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/1.22.yaml
+++ b/configs/foreman/1.22.yaml
@@ -35,7 +35,7 @@
       foreman-1.22-nonscl-rhel7-override:
         foreman-1.22-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -88,7 +88,7 @@
       foreman-1.22-rhel7-override:
         foreman-1.22-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -151,7 +151,7 @@
       foreman-plugins-1.22-nonscl-rhel7-override:
         foreman-plugins-1.22-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -207,7 +207,7 @@
       foreman-plugins-1.22-rhel7-override:
         foreman-plugins-1.22-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -384,7 +384,7 @@
         foreman-client-1.22-rhel7: 0
       foreman-client-1.22-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/1.23.yaml
+++ b/configs/foreman/1.23.yaml
@@ -35,7 +35,7 @@
       foreman-1.23-nonscl-rhel7-override:
         foreman-1.23-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -88,7 +88,7 @@
       foreman-1.23-rhel7-override:
         foreman-1.23-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -151,7 +151,7 @@
       foreman-plugins-1.23-nonscl-rhel7-override:
         foreman-plugins-1.23-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -205,7 +205,7 @@
       foreman-plugins-1.23-rhel7-override:
         foreman-plugins-1.23-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -382,7 +382,7 @@
         foreman-client-1.23-rhel7: 0
       foreman-client-1.23-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/1.24.yaml
+++ b/configs/foreman/1.24.yaml
@@ -34,7 +34,7 @@
       foreman-1.24-nonscl-rhel7-override:
         foreman-1.24-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -87,7 +87,7 @@
       foreman-1.24-rhel7-override:
         foreman-1.24-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -150,7 +150,7 @@
       foreman-plugins-1.24-nonscl-rhel7-override:
         foreman-plugins-1.24-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -204,7 +204,7 @@
       foreman-plugins-1.24-rhel7-override:
         foreman-plugins-1.24-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -381,7 +381,7 @@
         foreman-client-1.24-rhel7: 0
       foreman-client-1.24-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/2.0.yaml
+++ b/configs/foreman/2.0.yaml
@@ -32,7 +32,7 @@
       foreman-2.0-nonscl-rhel7-override:
         foreman-2.0-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -84,7 +84,7 @@
       foreman-2.0-rhel7-override:
         foreman-2.0-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -145,7 +145,7 @@
       foreman-plugins-2.0-nonscl-rhel7-override:
         foreman-plugins-2.0-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -198,7 +198,7 @@
       foreman-plugins-2.0-rhel7-override:
         foreman-plugins-2.0-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -373,7 +373,7 @@
         foreman-client-2.0-rhel7: 0
       foreman-client-2.0-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/2.1.yaml
+++ b/configs/foreman/2.1.yaml
@@ -33,7 +33,7 @@
       foreman-2.1-nonscl-rhel7-override:
         foreman-2.1-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -85,7 +85,7 @@
       foreman-2.1-rhel7-override:
         foreman-2.1-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -203,7 +203,7 @@
       foreman-plugins-2.1-nonscl-rhel7-override:
         foreman-plugins-2.1-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -256,7 +256,7 @@
       foreman-plugins-2.1-rhel7-override:
         foreman-plugins-2.1-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -540,7 +540,7 @@
         foreman-client-2.1-rhel7: 0
       foreman-client-2.1-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/2.2.yaml
+++ b/configs/foreman/2.2.yaml
@@ -33,7 +33,7 @@
       foreman-2.2-nonscl-rhel7-override:
         foreman-2.2-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -85,7 +85,7 @@
       foreman-2.2-rhel7-override:
         foreman-2.2-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -203,7 +203,7 @@
       foreman-plugins-2.2-nonscl-rhel7-override:
         foreman-plugins-2.2-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -256,7 +256,7 @@
       foreman-plugins-2.2-rhel7-override:
         foreman-plugins-2.2-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -540,7 +540,7 @@
         foreman-client-2.2-rhel7: 0
       foreman-client-2.2-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/2.3.yaml
+++ b/configs/foreman/2.3.yaml
@@ -32,7 +32,7 @@
       foreman-2.3-nonscl-rhel7-override:
         foreman-2.3-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -84,7 +84,7 @@
       foreman-2.3-rhel7-override:
         foreman-2.3-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -202,7 +202,7 @@
       foreman-plugins-2.3-nonscl-rhel7-override:
         foreman-plugins-2.3-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -255,7 +255,7 @@
       foreman-plugins-2.3-rhel7-override:
         foreman-plugins-2.3-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -487,7 +487,7 @@
         foreman-client-2.3-rhel7: 0
       foreman-client-2.3-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/foreman/nightly.yaml
+++ b/configs/foreman/nightly.yaml
@@ -29,7 +29,7 @@
       foreman-nightly-nonscl-rhel7-override:
         foreman-nightly-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - puppetlabs-puppet6-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -81,7 +81,7 @@
       foreman-nightly-rhel7-override:
         foreman-nightly-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -199,7 +199,7 @@
       foreman-plugins-nightly-nonscl-rhel7-override:
         foreman-plugins-nightly-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:
@@ -252,7 +252,7 @@
       foreman-plugins-nightly-rhel7-override:
         foreman-plugins-nightly-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -536,7 +536,7 @@
         foreman-client-nightly-rhel7: 0
       foreman-client-nightly-rhel7: {}
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server-updates
       - centos-7-server
     build_groups:

--- a/configs/katello/3.10.yaml
+++ b/configs/katello/3.10.yaml
@@ -96,7 +96,7 @@
       katello-3.10-rhel7:
         katello-3.10-thirdparty-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/3.11.yaml
+++ b/configs/katello/3.11.yaml
@@ -84,7 +84,7 @@
         katello-3.11-thirdparty-rhel7: 0
         foreman-1.21-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/3.12.yaml
+++ b/configs/katello/3.12.yaml
@@ -71,7 +71,7 @@
         katello-3.12-thirdparty-rhel7: 0
         foreman-1.22-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/3.13.yaml
+++ b/configs/katello/3.13.yaml
@@ -71,7 +71,7 @@
         katello-3.13-thirdparty-rhel7: 0
         foreman-1.23-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/3.14.yaml
+++ b/configs/katello/3.14.yaml
@@ -70,7 +70,7 @@
         katello-3.14-thirdparty-rhel7: 0
         foreman-1.24-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/3.15.yaml
+++ b/configs/katello/3.15.yaml
@@ -62,7 +62,7 @@
         katello-3.15-thirdparty-rhel7: 0
         foreman-2.0-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/3.16.yaml
+++ b/configs/katello/3.16.yaml
@@ -92,7 +92,7 @@
         katello-3.16-thirdparty-rhel7: 0
         foreman-2.1-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -135,7 +135,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7
   - name: katello-pulpcore-3.16-el8
     based_off: katello-pulpcore-nightly-el8
     helper_tags:

--- a/configs/katello/3.17.yaml
+++ b/configs/katello/3.17.yaml
@@ -74,7 +74,7 @@
         katello-3.17-thirdparty-rhel7: 0
         foreman-2.1-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server
@@ -95,4 +95,4 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7

--- a/configs/katello/3.18.yaml
+++ b/configs/katello/3.18.yaml
@@ -82,7 +82,7 @@
         katello-3.18-thirdparty-rhel7: 0
         foreman-2.3-nonscl-rhel7: 1
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/3.3.yaml
+++ b/configs/katello/3.3.yaml
@@ -101,7 +101,7 @@
     :external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
   - name: katello-3.3-rhel6

--- a/configs/katello/3.4.yaml
+++ b/configs/katello/3.4.yaml
@@ -122,7 +122,7 @@
     :external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
   - name: katello-3.4-rhel6

--- a/configs/katello/3.5.yaml
+++ b/configs/katello/3.5.yaml
@@ -121,7 +121,7 @@
     :external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
   - name: katello-3.5-rhel6

--- a/configs/katello/3.6.yaml
+++ b/configs/katello/3.6.yaml
@@ -106,7 +106,7 @@
     external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - foreman-rails-1.17-rhel-7

--- a/configs/katello/3.7.yaml
+++ b/configs/katello/3.7.yaml
@@ -187,7 +187,7 @@
     external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - foreman-rails-1.18-rhel-7

--- a/configs/katello/3.8.yaml
+++ b/configs/katello/3.8.yaml
@@ -211,7 +211,7 @@
         katello-3.8-rhel7: 0
         katello-3.8-thirdparty-pulp-rhel7: 2
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - centos-7-server

--- a/configs/katello/3.9.yaml
+++ b/configs/katello/3.9.yaml
@@ -87,7 +87,7 @@
       katello-3.9-rhel7:
         katello-3.9-thirdparty-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/katello/nightly.yaml
+++ b/configs/katello/nightly.yaml
@@ -39,7 +39,7 @@
       katello-nightly-rhel7:
         katello-thirdparty-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-7-server-updates
       - centos-7-server

--- a/configs/pulp/2.16.yaml
+++ b/configs/pulp/2.16.yaml
@@ -52,7 +52,7 @@
     external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
   - name: pulp-2.16-rhel6
     based_off: pulp-nightly-rhel6
     build_target: pulp-2.16-rhel6-build

--- a/configs/pulp/2.17.yaml
+++ b/configs/pulp/2.17.yaml
@@ -16,7 +16,7 @@
     external_repos:
       - rhel-7.0-server
       - rhel-7.0-server-optional
-      - epel-7
+      - epel7
   - name: pulp-2.17-rhel6
     based_off: pulp-nightly-rhel6
     build_target: pulp-2.17-rhel6-build

--- a/configs/pulp/2.18.yaml
+++ b/configs/pulp/2.18.yaml
@@ -49,7 +49,7 @@
     external_repos:
       - centos-7-server-updates
       - centos-7-server
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulp/2.19.yaml
+++ b/configs/pulp/2.19.yaml
@@ -16,7 +16,7 @@
     external_repos:
       - centos-7-server-updates
       - centos-7-server
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulp/2.20.yaml
+++ b/configs/pulp/2.20.yaml
@@ -18,7 +18,7 @@
     external_repos:
       - centos-7-server-updates
       - centos-7-server
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulp/2.21.yaml
+++ b/configs/pulp/2.21.yaml
@@ -18,7 +18,7 @@
     external_repos:
       - centos-7-server-updates
       - centos-7-server
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulp/2.nightly.yaml
+++ b/configs/pulp/2.nightly.yaml
@@ -17,7 +17,7 @@
     external_repos:
       - centos-7-server-updates
       - centos-7-server
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulp/3.nightly.yaml
+++ b/configs/pulp/3.nightly.yaml
@@ -18,7 +18,7 @@
       pulp3-nightly-rhel7-override:
         pulp3-nightly-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-sclo-rh-rhel-7
       - centos-sclo-sclo-rhel-7
       - centos-7-server
@@ -37,6 +37,6 @@
       pulp3-nightly-nonscl-rhel7-override:
         pulp3-nightly-nonscl-rhel7: 0
     external_repos:
-      - epel-7
+      - epel7
       - centos-7-server
       - rhel-7.0-server

--- a/configs/pulpcore/3.4.yaml
+++ b/configs/pulpcore/3.4.yaml
@@ -28,7 +28,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulpcore/3.5.yaml
+++ b/configs/pulpcore/3.5.yaml
@@ -26,7 +26,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulpcore/3.6.yaml
+++ b/configs/pulpcore/3.6.yaml
@@ -28,7 +28,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulpcore/3.7.yaml
+++ b/configs/pulpcore/3.7.yaml
@@ -28,7 +28,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulpcore/3.8.yaml
+++ b/configs/pulpcore/3.8.yaml
@@ -28,7 +28,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash

--- a/configs/pulpcore/3.9.yaml
+++ b/configs/pulpcore/3.9.yaml
@@ -28,7 +28,7 @@
       - centos7-os
       - centos7-updates
       - centos-sclo-rh-rhel-7
-      - epel-7
+      - epel7
     build_groups:
       build:
         - bash


### PR DESCRIPTION
epel-7 is the local 'file://' epel repo
epel7 is the 'https://' authoritative mirror for epel

This follows the same convention as centos7 vs centos-7 in external repos