### PR TITLE
Add 3.17.3 to prior releases

### DIFF
--- a/configs/katello/3.18.yaml
+++ b/configs/katello/3.18.yaml
@@ -9,6 +9,8 @@
   :3.18.2:
     :redmine_version_id: 1353
 :prior_releases:
+  :3.17.3:
+    :redmine_version_id: 1365
   :3.17.2:
     :redmine_version_id: 1342
   :3.17.1:

--- a/configs/katello/4.0.yaml
+++ b/configs/katello/4.0.yaml
@@ -5,6 +5,8 @@
   :4.0.0:
     :redmine_version_id: 1177
 :prior_releases:
+  :3.17.3:
+    :redmine_version_id: 1365
   :3.18.0:
     :redmine_version_id: 1272
   :3.18.1:


### PR DESCRIPTION
Eventually we're going to update Katello 4.0, 3.18, and 3.17 to pulp-rpm 3.9.  I'm adding 3.17.3 to 3.18 and 4.0 so that issue propagates. (https://projects.theforeman.org/issues/31785)