### PR TITLE
Fix flat-ruby27-el8 external repository priority

### DIFF
--- a/configs/foreman/2.5.yaml
+++ b/configs/foreman/2.5.yaml
@@ -144,8 +144,8 @@
       foreman-2.5-el8-override:
         foreman-2.5-el8: 0
     external_repos:
-      - test-flat-el8
       - flat-ruby27-el8
+      - test-flat-el8
       - centos8-devel
       - puppetlabs-puppet6-rhel-8
     build_groups:
@@ -316,8 +316,8 @@
       foreman-plugins-2.5-el8-override:
         foreman-plugins-2.5-el8: 0
     external_repos:
-      - test-flat-el8
       - flat-ruby27-el8
+      - test-flat-el8
     build_groups:
       build:
         - bash

--- a/configs/foreman/nightly.yaml
+++ b/configs/foreman/nightly.yaml
@@ -139,8 +139,8 @@
       foreman-nightly-el8-override:
         foreman-nightly-el8: 0
     external_repos:
-      - test-flat-el8
       - flat-ruby27-el8
+      - test-flat-el8
       - centos8-devel
       - puppetlabs-puppet6-rhel-8
     build_groups:
@@ -309,8 +309,8 @@
       foreman-plugins-nightly-el8-override:
         foreman-plugins-nightly-el8: 0
     external_repos:
-      - test-flat-el8
       - flat-ruby27-el8
+      - test-flat-el8
     build_groups:
       build:
         - bash

--- a/configs/katello/4.1.yaml
+++ b/configs/katello/4.1.yaml
@@ -97,6 +97,7 @@
       katello-4.1-el8:
         katello-thirdparty-el8: 0
     external_repos:
+      - flat-ruby27-el8
       - test-flat-el8
       - centos8-devel
       - puppetlabs-puppet6-rhel-8

--- a/configs/katello/nightly.yaml
+++ b/configs/katello/nightly.yaml
@@ -62,8 +62,8 @@
       katello-nightly-el8:
         katello-thirdparty-el8: 0
     external_repos:
-      - test-flat-el8
       - flat-ruby27-el8
+      - test-flat-el8
       - centos8-devel
       - puppetlabs-puppet6-rhel-8
     build_groups:


### PR DESCRIPTION
The flattened Ruby 2.7 repository needs to come before the primary
EL8 flat repository in priority to prevent the base Ruby 2.5 from
being seen as the available Ruby.

I have fixed this in Koji.