### PR TITLE
trigger packaging release once to setup hooks

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -126,6 +126,7 @@ The next step should only be done after all branching, including packaging, has 
   - [ ] foreman-packaging's rpm/<%= release %>
     - [ ] Update `packages/foreman/foreman-release/foreman.gpg`, `mock/*.cfg`, `package_manifest.yaml`, `rel-eng/{releasers.conf,tito.props}` and `repoclosure/*.conf`
 - [ ] Update `https://github.com/theforeman/foreman-infra/blob/master/puppet/modules/jenkins_job_builder/files/centos.org/jobs/foreman-pipeline-template.yml` to expect <%= develop %>.0-develop for nightlies
+- [ ] Trigger the [`foreman-packaging-rpm-<%= release %>`](https://ci.theforeman.org/job/foreman-packaging-rpm-<%= release %>-release/) job once, so that GitHub hooks are properly set up.
 
 # Other systems: <%= target_date %>
 


### PR DESCRIPTION
otherwise the merges to rpm/$release won't trigger builds