### PR TITLE
Improve error message for 'No such file or directory' error

### DIFF
--- a/lib/tool_belt/release_environment.rb
+++ b/lib/tool_belt/release_environment.rb
@@ -48,6 +48,9 @@ module ToolBelt
           Dir.chdir(name.to_s) do
             @systools.execute("git fetch --all")
           end
+        rescue Errno::ENOENT => e
+          new_message = e.message + ". Do you need to re-run setup-environment?"
+          raise Errno::ENOENT, new_message
         end
       end
     end


### PR DESCRIPTION
If you try to run `cherry-picks` after adding some repos to your config, and forget to run the `setup-environment` command first, you'll get an error like:
```
Traceback (most recent call last):
	11: from ./tools.rb:21:in `<main>'
	10: from /home/vagrant/.gem/ruby/gems/clamp-1.3.2/lib/clamp/command.rb:140:in `run'
	 9: from /home/vagrant/.gem/ruby/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
	 8: from /home/vagrant/.gem/ruby/gems/clamp-1.3.2/lib/clamp/subcommand/execution.rb:18:in `execute'
	 7: from /home/vagrant/.gem/ruby/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
	 6: from /home/vagrant/tool_belt/lib/tool_belt/commands/cherry_pick_command.rb:14:in `execute'
	 5: from /home/vagrant/tool_belt/lib/tool_belt/release_environment.rb:46:in `update_repos'
	 4: from /home/vagrant/tool_belt/lib/tool_belt/release_environment.rb:46:in `chdir'
	 3: from /home/vagrant/tool_belt/lib/tool_belt/release_environment.rb:47:in `block in update_repos'
	 2: from /home/vagrant/tool_belt/lib/tool_belt/release_environment.rb:47:in `each'
	 1: from /home/vagrant/tool_belt/lib/tool_belt/release_environment.rb:48:in `block (2 levels) in update_repos'
/home/vagrant/tool_belt/lib/tool_belt/release_environment.rb:48:in `chdir': No such file or directory @ dir_chdir - smart_proxy_container_gateway (Errno::ENOENT)
```

This improves the error to say something like:
```
/home/vagrant/tool_belt/lib/tool_belt/release_environment.rb:48:in `chdir': No such file or directory @ dir_chdir - 
smart_proxy_container_gateway (Errno::ENOENT). Do you need to re-run setup-environment?
```