### PR TITLE
Switch from centos7-os to centos-7-server external repositories

### DIFF
--- a/configs/katello/3.15.yaml
+++ b/configs/katello/3.15.yaml
@@ -6,7 +6,7 @@
   :3.15.3:
     :redmine_version_id: 1257
   :3.15.2:
-    :redmine_version_id: 1238 
+    :redmine_version_id: 1238
   :3.15.1:
     :redmine_version_id: 1211
   :3.15.0:
@@ -80,5 +80,5 @@
         katello-pulpcore-3.15-el7: 0
     build_package_group_source_tag: katello-pulpcore-nightly-el7-build
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates

--- a/configs/katello/3.16.yaml
+++ b/configs/katello/3.16.yaml
@@ -2,7 +2,7 @@
 :project: katello
 :github_org: katello
 :releases:
-  :3.16.2: 
+  :3.16.2:
     :redmine_version_id: 1308
   :3.16.1.2:
     :redmine_version_id: 1313
@@ -132,8 +132,8 @@
         katello-pulpcore-3.16-el7: 0
     build_package_group_source_tag: katello-pulpcore-nightly-el7-build
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
   - name: katello-pulpcore-3.16-el8

--- a/configs/katello/3.17.yaml
+++ b/configs/katello/3.17.yaml
@@ -92,7 +92,7 @@
         katello-pulpcore-3.17-el7: 0
     build_package_group_source_tag: katello-pulpcore-nightly-el7-build
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7

--- a/configs/pulpcore/3.11.yaml
+++ b/configs/pulpcore/3.11.yaml
@@ -25,8 +25,8 @@
       pulpcore-3.11-el7-override:
         pulpcore-3.11-el7: 0
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
     build_groups:

--- a/configs/pulpcore/3.4.yaml
+++ b/configs/pulpcore/3.4.yaml
@@ -25,8 +25,8 @@
       pulpcore-3.4-el7-override:
         pulpcore-3.4-el7: 0
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
     build_groups:

--- a/configs/pulpcore/3.5.yaml
+++ b/configs/pulpcore/3.5.yaml
@@ -23,8 +23,8 @@
       pulpcore-3.5-el7-override:
         pulpcore-3.5-el7: 0
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
     build_groups:

--- a/configs/pulpcore/3.6.yaml
+++ b/configs/pulpcore/3.6.yaml
@@ -25,8 +25,8 @@
       pulpcore-3.6-el7-override:
         pulpcore-3.6-el7: 0
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
     build_groups:

--- a/configs/pulpcore/3.7.yaml
+++ b/configs/pulpcore/3.7.yaml
@@ -25,8 +25,8 @@
       pulpcore-3.7-el7-override:
         pulpcore-3.7-el7: 0
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
     build_groups:

--- a/configs/pulpcore/3.8.yaml
+++ b/configs/pulpcore/3.8.yaml
@@ -25,8 +25,8 @@
       pulpcore-3.8-el7-override:
         pulpcore-3.8-el7: 0
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
     build_groups:

--- a/configs/pulpcore/3.9.yaml
+++ b/configs/pulpcore/3.9.yaml
@@ -25,8 +25,8 @@
       pulpcore-3.9-el7-override:
         pulpcore-3.9-el7: 0
     external_repos:
-      - centos7-os
-      - centos7-updates
+      - centos-7-server
+      - centos-7-server-updates
       - centos-sclo-rh-rhel-7
       - epel-7
     build_groups:


### PR DESCRIPTION
Koji has duplicate external repositories for CentOS 7 Server and
Updates and this consolidates the use.