### PR TITLE
Declare explicit roles in procedures

### DIFF
--- a/lib/tool_belt/commands/procedure.rb
+++ b/lib/tool_belt/commands/procedure.rb
@@ -10,6 +10,8 @@ module ToolBelt
           value
         end
         parameter "target-date", "Target date that the procedure should be completed on"
+        parameter "owner", "The release owner's username on Discourse"
+        parameter "engineer", "The release engineer's username on Discourse"
 
         def execute
           parsed_date = Date.parse(target_date)
@@ -20,6 +22,8 @@ module ToolBelt
             target_date: parsed_date,
             two_weeks_before: parsed_date - 14,
             one_week_before: parsed_date - 7,
+            owner: discourse_username(owner),
+            engineer: discourse_username(engineer),
           }
 
           render(project, 'branch', context)
@@ -33,6 +37,8 @@ module ToolBelt
           value
         end
         parameter "target-date", "Target date that the procedure should be completed on"
+        parameter "owner", "The release owner's username on Discourse"
+        parameter "engineer", "The release engineer's username on Discourse"
 
         def execute
           version, extra = full_version.split('-', 2)
@@ -51,6 +57,8 @@ module ToolBelt
             target_date: parsed_date,
             two_weeks_before: parsed_date - 14,
             one_week_before: parsed_date - 7,
+            owner: discourse_username(owner),
+            engineer: discourse_username(engineer),
           }
 
           render(project, 'release', context)
@@ -93,6 +101,10 @@ module ToolBelt
       def previous_release(version)
         parts = version.split('.')
         (parts[0..-2] + [(parts.last.to_i - 1).to_s]).join('.')
+      end
+
+      def discourse_username(name)
+        name.start_with?('@') ? name : "@#{name}"
       end
     end
   end

--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -1,5 +1,11 @@
 [ ] Make this post a wiki
 
+## Roles
+
+* Release Owner: <%= owner %>
+* Release Engineer: <%= engineer %>
+* Installer Maintainer: @
+
 # Prep Week: <%= two_weeks_before %> to <%= two_weeks_before + 4 %>
 
 ## Installer Maintainer

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -1,6 +1,14 @@
 [ ] Make this post a wiki
 
+## Roles
+
+* Release Owner: <%= owner %>
+* Release Engineer: <%= engineer %>
+* Installer Maintainer: @
+
 # Manual updates: <%= target_date %>
+
+## Release Engineer
 
 - [ ] Update manual if applicable for any additional installation steps
 - Update [release notes section](gh-pages/_includes/manuals/<%= short_version %>/1.2_release_notes.md) in the manual:
@@ -17,8 +25,13 @@
 
 # Preparing code: <%= target_date %>
 
+## Installer Maintainer
+
 - [ ] Make patch releases of installer modules that have important changes
   - [ ] Branch to MAJ.MIN-stable if recent changes to the module aren't suitable for patch (x.y.z) release
+
+## Release Owner
+
 <% unless (is_rc || full_version.end_with?('0')) %>- [ ] Add a new [Redmine version](https://projects.theforeman.org/projects/foreman/settings/versions) for the next minor, unless the series is EOL. Be sure the version is set to sharing with subprojects.
 <% end %>- [ ] Remove/change target version field for any open Redmine tickets assigned to the release still (next minor, unset it or reject)
 - [ ] Ensure that code in git matches issues fixed in <%= full_version %> in redmine. [issues.rb](https://gist.github.com/tbrisker/3320097f1d8c9abfb2dbcf8d8e216bba) can be used to generate a comparison between the two.
@@ -26,6 +39,8 @@
 <% end %>
 
 # Tagging a release: <%= target_date %>
+
+## Release Owner
 
 - In foreman <%= short_version %>-stable:
   - [ ] Make sure [test_<%= short_version.tr('.', '_') %>_stable](https://ci.theforeman.org/job/test_<%= short_version.tr('.', '_') %>_stable/) is green
@@ -39,6 +54,9 @@
 - In foreman-installer <%= short_version %>-stable:
   - [ ] Tag the release using [tag.sh](https://gist.github.com/tbrisker/d51cedea51ccbcca00e72c1fc61550fe) `tag.sh <%= full_version %> && git push upstream <%= short_version %>-stable --follow-tags`
 - [ ] Run the Jenkins [Tarballs Release](https://ci.theforeman.org/job/tarballs-release/) to create tarballs
+
+## Release Engineer
+
 - [ ] Update release version similar to [here](https://github.com/theforeman/theforeman-rel-eng/commit/2029a9688da00d9c385c3438dd71b594ba5f728e)
 - [ ] Sign Tarballs
   - [ ] [Download](https://github.com/theforeman/theforeman-rel-eng/blob/master/download_tarballs)
@@ -48,6 +66,8 @@
 Note: If for some reason there was an issue with the tarballs that required uploading new tarballs, CDN cache should be invalidated so that the builders use the updated tarballs.
 
 # Packaging a release: <%= target_date %>
+
+## Release Engineer
 
 [Background documentation](https://projects.theforeman.org/projects/foreman/wiki/Release_Process#Packaging-a-release)
 
@@ -76,6 +96,8 @@ Note: If for some reason there was an issue with the tarballs that required uplo
 - [ ] Kick off the [plugins pipeline](https://ci.theforeman.org/job/foreman-plugins-<%= short_version %>-rpm-pipeline/) by calling [plugins_pipeline](https://github.com/theforeman/theforeman-rel-eng/blob/master/plugins_pipeline)
 
 # After the packages have been released
+
+# Release Owner
 
 <% unless is_rc %>- [ ] Update the versions on the website in [version](https://github.com/theforeman/theforeman.org/blob/gh-pages/_includes/version.html) and [latest news](https://github.com/theforeman/theforeman.org/blob/gh-pages/_includes/latest_news.html)
 <% end -%>

--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -1,3 +1,10 @@
+[ ] Make this post a wiki
+
+## Roles
+
+* Release Owner: <%= owner %>
+* Release Engineer: <%= engineer %>
+
 # One Month Prior to Branch Date
 
 ## Release Owner
@@ -31,7 +38,7 @@
   - [ ] [foreman_proxy_content](https://github.com/theforeman/puppet-foreman_proxy_content)
   - [ ] [katello](https://github.com/theforeman/puppet-katello)
 
-## Release Packager
+## Release Engineer
 
 - [ ] Ensure tool_belt config is merged and output from `./tools.rb koji configs/katello/<%= release %>.yaml` matches expectations
 
@@ -65,7 +72,7 @@
       find $GITDIR/theforeman.org/plugins/katello/$VERSION/api -name "*.json" -type f -delete
       sed -i "/layout: /d" $GITDIR/theforeman.org/plugins/katello/$VERSION/api/index.md
 
-## Release Packager
+## Release Engineer
 
 - [ ] Run `./tools koji configs/katello/<%= release %>.yaml` from [tool_belt](https://github.com/theforeman/tool_belt) to create Koji tags
 - [ ] Run `./tools mash-scripts configs/katello/<%= release %>.yaml` from [tool_belt](https://github.com/theforeman/tool_belt) to create Koji mash configs and open PR to tool_belt to commit

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -1,3 +1,10 @@
+[ ] Make this post a wiki
+
+## Roles
+
+* Release Owner: <%= owner %>
+* Release Engineer: <%= engineer %>
+
 # When Ready to Release
 
 ## Release Owner
@@ -22,7 +29,7 @@
 
 # Once Source is Available
 
-## Release Packager
+## Release Engineer
 
 - [ ] Update `katello`, `katello-repos` and `rubygem-katello` in [foreman-packaging](https://github.com/theforeman/foreman-packaging) [rpm/<%= short_version %>](https://github.com/theforeman/theforeman-rel-eng/blob/master/bump_rpm_packaging) branch (replace <%= short_version %> with the matching Foreman version):
   - [ ] `obal update katello katello-repos rubygem-katello --version <%= version %><% if is_rc %> --prerelease <%= extra %> --release keep<% end %>`


### PR DESCRIPTION
In Foreman Release there were no explicit roles so those were added.

It also aligns Foreman and Katello naming for the Release Engineer role.

This implements point 1 and 3 as laid out in the [communication RFC](https://community.theforeman.org/t/branching-release-process-communication/23965). The second point is something humans should adopt.

Also includes an unrelated fix to use the tarballs_release script.