### PR TITLE
Only release on days with a working day after

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -66,6 +66,10 @@
 Note: If for some reason there was an issue with the tarballs that required uploading new tarballs, CDN cache should be invalidated so that the builders use the updated tarballs.
 
 # Packaging a release: <%= target_date %>
+<% unless is_rc -%>
+
+**Note** it is considered good practice to release on a day when the next day is a working day. This means no releases on Fridays or on the day before a holiday.
+<% end -%>
 
 ## Release Engineer
 

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -28,6 +28,10 @@
   - [ ] Push gem: `gem push katello-<%= full_version %>.gem`
 
 # Once Source is Available
+<% unless is_rc -%>
+
+**Note** it is considered good practice to release on a day when the next day is a working day. This means no releases on Fridays or on the day before a holiday.
+<% end -%>
 
 ## Release Engineer
 


### PR DESCRIPTION
It is considered good practice to release on a day when there is a working day following it. The risk is that something does break and if you have to wait a whole weekend to fix it, it's bad. Note that goes not only for users but also developers.

This is all not relevant for release candidates. Everyone should be aware that release candidates are not meant for production and the risks associated with them.