### PR TITLE
Do not request installer releases for RC1

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -4,7 +4,9 @@
 
 * Release Owner: <%= owner %>
 * Release Engineer: <%= engineer %>
+<% unless is_rc -%>
 * Installer Maintainer: @
+<% end -%>
 
 # Manual updates: <%= target_date %>
 
@@ -24,11 +26,13 @@
 <% end %>
 
 # Preparing code: <%= target_date %>
+<% unless is_rc -%>
 
 ## Installer Maintainer
 
 - [ ] Make patch releases of installer modules that have important changes
   - [ ] Branch to MAJ.MIN-stable if recent changes to the module aren't suitable for patch (x.y.z) release
+<% end -%>
 
 ## Release Owner
 


### PR DESCRIPTION
RC1 immediately follows branching. During branching releases have been made so there's no need to create more. This also means we can remove the installer maintainer from the list.