### PR TITLE
Allow options and parameters in any order

### DIFF
--- a/tools.rb
+++ b/tools.rb
@@ -4,6 +4,8 @@ require 'clamp'
 
 require File.join(File.dirname(__FILE__), 'lib/tool_belt')
 
+Clamp.allow_options_after_parameters = true
+
 class MainCommand < Clamp::Command
 
   subcommand "cherry-picks", "Calculate needed cherry picks for a given release configuration", ToolBelt::Command::CherryPickCommand


### PR DESCRIPTION
Allows something like the following to now work:

```
./tools.rb koji config/nightly/foreman.yaml --help
```