### PR TITLE
don't install non-scl python rpm macros

### DIFF
--- a/configs/pulpcore/3.15.yaml
+++ b/configs/pulpcore/3.15.yaml
@@ -45,7 +45,6 @@
         - info
         - make
         - patch
-        - python3-rpm-macros
         - redhat-release
         - redhat-rpm-config
         - rpm-build
@@ -62,7 +61,6 @@
         - xz
       srpm-build:
         - bash
-        - python3-rpm-macros
         - rh-postgresql12-scldevel
         - rh-python38-scldevel
         - rh-python38-python-rpm-macros


### PR DESCRIPTION
nobody needs them