### PR TITLE
add python36 to pulpcore 3.15

### DIFF
--- a/configs/pulpcore/3.15.yaml
+++ b/configs/pulpcore/3.15.yaml
@@ -87,6 +87,8 @@
     external_repos:
       - name: flat-base-el8
         mode: bare
+      - name: flat-python36-el8
+        mode: bare
       - name: flat-python38-el8
         mode: bare
       - name: flat-python38-devel-el8


### PR DESCRIPTION
we still need to be able to build against 3.6 python