### PR TITLE
Add config for Katello 4.4

### DIFF
--- a/configs/katello/4.4.yaml
+++ b/configs/katello/4.4.yaml
@@ -1,0 +1,142 @@
+---
+:project: katello
+:github_org: katello
+:releases:
+  :4.4.0:
+    :redmine_version_id: 1517
+:prior_releases:
+  :4.3.1:
+    :redmine_version_id: 1535
+:code_name: Habanero
+:mash_scripts:
+  - katello-4.4-rhel7
+  - katello-4.4-thirdparty-candlepin-rhel7
+  - katello-4.4-el8
+  - katello-candlepin-4.4-el8
+:repos:
+  :katello:
+    :main: true
+    :branch: KATELLO-4.4
+    :repo: https://github.com/Katello/katello.git
+    :version_branch: true
+  :foreman-packaging:
+    :branch: rpm/3.2
+    :repo: https://github.com/theforeman/foreman-packaging.git
+  :hammer-cli-katello:
+    :branch: 1.4.z
+    :repo: https://github.com/Katello/hammer-cli-katello.git
+  :katello-host-tools:
+    :branch: 3.5.7
+    :repo: https://github.com/Katello/katello-host-tools.git
+  :katello-certs-tools:
+    :branch: 2.9.0
+    :repo: https://github.com/Katello/katello-certs-tools.git
+  :foreman_virt_who_configure:
+    :branch: 0.5.8
+    :repo: https://github.com/theforeman/foreman_virt_who_configure.git
+  :smart_proxy_container_gateway:
+    :branch: 1.0.6
+    :repo: https://github.com/Katello/smart_proxy_container_gateway.git
+  :katello-selinux:
+    :branch: 4.0.2
+    :repo: https://github.com/Katello/katello-selinux.git
+:ignores:
+:strict_keys: true
+:gpg_key: 6DA7EB32
+:tags:
+  - name: katello-4.4-thirdparty-candlepin-rhel7
+    based_off: null
+    build_target: katello-4.4-rhel7-build
+    arches:
+      - x86_64
+  - name: katello-candlepin-4.4-el8
+    based_off: null
+    build_target: katello-4.4-el8-build
+    arches:
+      - x86_64
+  - name: katello-4.4-rhel7
+    based_off: null
+    helper_tags:
+      katello-thirdparty-rhel7: null
+      katello-4.4-rhel7-override: null
+    build_target: katello-4.4-rhel7-build
+    build_package_group_source_tag: katello-4.4-rhel7-build
+    arches:
+      - x86_64
+    inherits:
+      katello-4.4-rhel7-build:
+        katello-4.4-rhel7-override: 0
+        foreman-plugins-3.0-rhel7: 3
+        foreman-plugins-3.0-nonscl-rhel7: 4
+        foreman-3.2-rhel7: 5
+        foreman-3.2-nonscl-rhel7: 6
+      katello-4.4-rhel7-override:
+        katello-4.4-rhel7: 0
+      katello-4.4-rhel7:
+        katello-thirdparty-rhel7: 0
+    external_repos:
+      - epel-7
+      - centos-sclo-rh-rhel-7
+      - centos-7-server-updates
+      - centos-7-server
+  - name: katello-4.4-el8
+    based_off: null
+    helper_tags:
+      katello-thirdparty-el8: null
+      katello-4.4-el8-override: null
+    build_target: katello-4.4-el8-build
+    build_package_group_source_tag: katello-4.4-el8-build
+    arches:
+      - x86_64
+    inherits:
+      katello-4.4-el8-build:
+        katello-4.4-el8-override: 0
+        foreman-plugins-3.0-el8: 3
+        foreman-3.2-el8: 5
+      katello-4.4-el8-override:
+        katello-4.4-el8: 0
+      katello-4.4-el8:
+        katello-thirdparty-el8: 0
+    external_repos:
+      - flat-ruby27-el8
+      - test-flat-el8
+      - centos8-devel
+    build_groups:
+      build:
+        - bash
+        - bzip2
+        - centos-release
+        - coreutils
+        - cpio
+        - diffutils
+        - findutils
+        - foreman-build
+        - gawk
+        - gcc
+        - gcc-c++
+        - grep
+        - gzip
+        - info
+        - make
+        - patch
+        - platform-python
+        - python3-rpm-macros
+        - redhat-rpm-config
+        - rpm-build
+        - sed
+        - shadow-utils
+        - tar
+        - unzip
+        - util-linux
+        - which
+        - xz
+      srpm-build:
+        - bash
+        - centos-release
+        - foreman-build
+        - platform-python
+        - python3-rpm-macros
+        - redhat-rpm-config
+        - rhpkg-simple
+        - rpm-build
+        - shadow-utils


### PR DESCRIPTION
Here's the new config for Katello 4.4.

Some issues and things I'm not sure about right now:

1) The Foreman 3.2 GPG key isn't available yet
2) I'm not certain I named the tags correctly. They seem to be different from Katello 4.3.  I just based them off of nightly and replaced 'nightly' with the applicable version number.
3) Was it right to increase the version of katello-certs-tools to 2.8.2?