### PR TITLE
Add Katello branching procedure steps for Katello Next

### DIFF
--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -90,6 +90,12 @@
       cp -rf public/apipie-cache/* $GITDIR/theforeman.org/plugins/katello/$VERSION/api
       find $GITDIR/theforeman.org/plugins/katello/$VERSION/api -name "*.json" -type f -delete
       sed -i "/layout: /d" $GITDIR/theforeman.org/plugins/katello/$VERSION/api/index.md
+- [ ] Prepare "Katello Next" and future redmine versions
+  - [ ] Rename the "Katello Next" release to Katello <%= develop %>.0
+  - [ ] Recreate the "Katello Next" release and indicate that it is a placeholder for issues belonging to the next version of Katello
+  - [ ] Create the next 'z' release: Katello <%= release %>.1
+  - [ ] Create the "Katello <%= release %>.1 TODO" custom query using the last one as a template
+
 
 ## Release Engineer
 


### PR DESCRIPTION
In order to better sync-up with Foreman release practices, Katello will wait until branching to create the latest release in redmine.  If, say, Katello 4.5.0 is created in redmine before Katello 4.4.0 has branched, the "fixed in version" field will incorrectly be set by prprocessor to 4.5.0.  To work around this, all future bugs that should be on a version after the latest pre-branched version will be triaged to "Katello Next".

For now, it will be up to the release owner to update Katello Next and related redmine releases at branching time.  The new instructions below illustrate this.

@ekohl wrote up some more detailed notes here: https://community.theforeman.org/t/release-team-meeting-agenda-2022-02-09/27243/3