### PR TITLE
Create Katello jenkins-jobs PR and look at Foreman RC date earlier into branching

### DIFF
--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -52,7 +52,9 @@
   - [ ] [pulpcore](https://github.com/theforeman/puppet-pulpcore)
   - [ ] [foreman_proxy_content](https://github.com/theforeman/puppet-foreman_proxy_content)
   - [ ] [katello](https://github.com/theforeman/puppet-katello)
-- [ ] Create PR to [jenkins-jobs](https://github.com/theforeman/jenkins-jobs) to add a mapping between the current Foreman and Katello release branches. Also remove the oldest mapping from the config. See [this example](https://github.com/theforeman/jenkins-jobs/pull/54).
+- [ ] Create PRs to [jenkins-jobs](https://github.com/theforeman/jenkins-jobs) to add a mapping between the current Foreman and Katello release branches and update pipelines. See [this test mapping PR example](https://github.com/theforeman/jenkins-jobs/pull/179) and [this pipeline PR example](https://github.com/theforeman/jenkins-jobs/pull/178).
+- [ ] Files to edit: [testKatello.groovy](https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/pipelines/test/testKatello.groovy), [katello-pipelines.yml](https://github.com/theforeman/jenkins-jobs/blob/master/centos.org/jobs/katello-pipelines.yml), and [katello-rpm-pipeline.yaml](https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/yaml/jobs/pipeline/katello-rpm-pipeline.yaml).
+  - [ ] File to create: [<%= release %>.groovy](https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/pipelines/vars/katello/<%= release %>.groovy).  Copy [nightly.groovy](https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/pipelines/vars/katello/nightly.groovy) and replace the Foreman and Katello versions in the file accordingly.
 - [ ] Review the Foreman schedule and planning ([example](https://community.theforeman.org/t/foreman-2-5-schedule-and-planning/22219)) and note the date of the first scheduled release candidate.
 
 ## Release Engineer
@@ -81,15 +83,7 @@
   - [ ] Create a pull request to `theforeman/foreman-documentation`:
     - [ ] Locate the Foreman documentation PR for the current version - [example here](https://github.com/theforeman/foreman-documentation/pull/515)
     - [ ] Add Katello-related content in the same file and base the PR off of the Foreman PR
-- [ ] Update API docs and open a PR with the changes:
-
-      VERSION=<%= short_version %>
-      GITDIR=~/git  #directory containing theforeman.org git repo
-
-      FOREMAN_APIPIE_LANGS=en rake apipie:cache
-      cp -rf public/apipie-cache/* $GITDIR/theforeman.org/plugins/katello/$VERSION/api
-      find $GITDIR/theforeman.org/plugins/katello/$VERSION/api -name "*.json" -type f -delete
-      sed -i "/layout: /d" $GITDIR/theforeman.org/plugins/katello/$VERSION/api/index.md
+  - [ ] Clone https://github.com/theforeman/apidocs and follow the Katello README section to update the API documentation.
 - [ ] Prepare "Katello Next" and future redmine versions
   - [ ] Rename the "Katello Next" release to Katello <%= develop %>.0
   - [ ] Recreate the "Katello Next" release and indicate that it is a placeholder for issues belonging to the next version of Katello

--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -52,6 +52,8 @@
   - [ ] [pulpcore](https://github.com/theforeman/puppet-pulpcore)
   - [ ] [foreman_proxy_content](https://github.com/theforeman/puppet-foreman_proxy_content)
   - [ ] [katello](https://github.com/theforeman/puppet-katello)
+- [ ] Create PR to [jenkins-jobs](https://github.com/theforeman/jenkins-jobs) to add a mapping between the current Foreman and Katello release branches. Also remove the oldest mapping from the config. See [this example](https://github.com/theforeman/jenkins-jobs/pull/54).
+- [ ] Review the Foreman schedule and planning ([example](https://community.theforeman.org/t/foreman-2-5-schedule-and-planning/22219)) and note the date of the first scheduled release candidate.
 
 ## Release Engineer
 
@@ -65,8 +67,6 @@
   - [ ] [katello](https://github.com/katello/katello)
 - [ ] Bump versions to <%= develop %>-master
   - [ ] [katello](https://github.com/katello/katello)
-- [ ] Create PR to [jenkins-jobs](https://github.com/theforeman/jenkins-jobs) to add a mapping between the current Foreman and Katello release branches. Also remove the oldest mapping from the config. See [this example](https://github.com/theforeman/jenkins-jobs/pull/54).
-- [ ] Review the Foreman schedule and planning ([example](https://community.theforeman.org/t/foreman-2-5-schedule-and-planning/22219)) and note the date of the first scheduled release candidate.
 - [ ] Generate and post the release procedure, if not already posted:
   - [ ] (Note that Katello uses dots instead of dashes for release candidates, e.g. 4.1.1.rc1 not 4.1.1-rc1)
   - [ ] Make sure to run `./tools.rb setup-environment` first

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -18,15 +18,16 @@
 - [ ] Do Cherry-picks: Clone [tool_belt](https://github.com/theforeman/tool_belt)
   - [ ] If any minor versions of Katello have been added to Redmine since the last cherry-pick, make sure to include them in `prior_releases` in configs/katello/<%= short_version %>.yaml
   - [ ] Run `./tools.rb setup-environment configs/katello/<%= short_version %>.yaml`
-  - [ ] Run `./tools.rb cherry-picks --version <%= full_version %> configs/katello/<%= short_version %>.yaml`
+  - [ ] Run `GITHUB_ACCESS_TOKEN=<secret> ./tools.rb cherry-picks --version <%= full_version %> configs/katello/<%= short_version %>.yaml`
   - [ ] Open a PR in Katello release branch.  Make sure the PR name starts with [CP] to prevent our automations from adding it to Redmine issues.
   - [ ] Using `git cherry-pick -x` as needed, verify tickets in the cherry_picks_<%= full_version %> file are accounted for, or additionally cherry-pick them.  Recommended: Do this in tool_belt's checkout of Katello, in `repos/katello/<%= full_version %>/katello`. This way when you run cherry-picks again, tool_belt will be aware of any picks already completed.
   - [ ] For any cherry-picks that are not needed (including Redmine trackers) you can add them to the `:ignores:` section of `tool_belt` in `configs/katello/<%= short_version %>.yaml`
 - [ ] Check for outdated deprecation warnings in the current and next release with `./tools check-deprecation-warnings configs/katello/<%= short_version %>.yaml`. Follow the instructions in the output of the command. Don't forget to create any Redmine issues needed!
 
-- [ ] Bump version:
-  - [ ] Open a PR (or use cherry-pick PR) against the release branch which updates `lib/katello/version.rb` to <%= full_version %>
+- [ ] Open a PR (or use cherry-pick PR) against the release branch which updates `lib/katello/version.rb` to <%= full_version %>:
   - [ ] `git pull` to make sure you have the latest changes
+  - [ ] `sed '/VERSION/ s/".\+"/"<%= full_version %>"/' lib/katello/version.rb`
+  - [ ] Update/add the CHANGELOG.md file: `GITHUB_ACCESS_TOKEN=<secret> ./tools changelog configs/katello/<%= short_version %>.yaml`
   - [ ] Commit: `git commit -m "Release <%= full_version %>"`
   - [ ] Ensure that the commit above is the _last_ commit and there are no commits after it. This is the commit that will get tagged. (Rearrange commits with `git rebase -i` if needed.)
 - [ ] Once the PR is merged, perform the following in the Katello release branch (the real one, not your fork):
@@ -58,6 +59,7 @@
 
 - [ ] Confirm response that the build succeeded (or if necessary, do more cherry-picks and version bumps repeating the steps above)
 - [ ] Post a [release announcement](https://community.theforeman.org/c/release-announcements/8)
-<% unless is_rc %>
+<% if !is_rc && full_version.end_with?('.0') %>
 - [ ] Create and upload [release specific developer stable box](https://github.com/theforeman/forklift/blob/master/packer/README.md#creating-version-specific-katello-devel-boxes)
+- [ ] Remove references to the oldest Katello version from [testKatello.groovy](https://github.com/theforeman/jenkins-jobs/blob/master/theforeman.org/pipelines/test/testKatello.groovy) and [katello-pipelines.yml](https://github.com/theforeman/jenkins-jobs/blob/master/centos.org/jobs/katello-pipelines.yml).
 <% end %>


### PR DESCRIPTION
The jenkins-jobs PR for the Foreman-Katello test mapping can be done earlier to put less pressure on branching day.  I also moved the note to review the Foreman schedule up.