### PR TITLE
Update Foreman release procedure formatting

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -17,13 +17,15 @@
   - [ ] Release notes: bullet point list by category of all changes, include link to bug numbers. You can auto-generate changes using the [release notes script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/release_notes.rb).
   - [ ] CLI release notes are taken from the hammer-cli and hammer-cli-foreman changelogs
   - [ ] Link to installer changelogs and note versions being used
-<% if (is_rc || full_version.end_with?('0')) %>  - [ ] Headline features: half a dozen important features with a few sentences description each
+<% if (is_rc || full_version.end_with?('0')) -%>
+  - [ ] Headline features: half a dozen important features with a few sentences description each
   - [ ] Upgrade notes: all important notices that users must be aware of before upgrading
 - [ ] Update installer options section using the [get-params script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/installer/get-params) (Note: this step can only be done after packages are released)
 [ ] [Generate](https://github.com/theforeman/apidocs#adding-new-version) the apipie docs and raise pull request in [apidocs](https://github.com/theforeman/apidocs) repository
-<% else %>- [ ] Update installer options section using the [get-params script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/installer/get-params) if any changes were made in the installer or installer modules (after new packages have been released)
+<% else -%>
+- [ ] Update installer options section using the [get-params script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/installer/get-params) if any changes were made in the installer or installer modules (after new packages have been released)
 - [ ] [Update](https://github.com/theforeman/apidocs#adding-new-version) the apipie docs and place those in the [foreman/<%= short_version %>/apidoc](https://github.com/theforeman/apidocs/tree/gh-pages/foreman/<%= short_version %>/apidoc) directory if any changes were made to the API
-<% end %>
+<% end -%>
 
 # Preparing code: <%= target_date %>
 <% unless is_rc && full_version.end_with?('1') -%>
@@ -36,11 +38,14 @@
 
 ## Release Owner
 
-<% unless (is_rc || full_version.end_with?('0')) %>- [ ] Add a new [Redmine version](https://projects.theforeman.org/projects/foreman/settings/versions) for the next minor, unless the series is EOL. Be sure the version is set to sharing with subprojects.
-<% end %>- [ ] Remove/change target version field for any open Redmine tickets assigned to the release still (next minor, unset it or reject)
+<% unless (is_rc || full_version.end_with?('.0')) -%>
+- [ ] Add a new [Redmine version](https://projects.theforeman.org/projects/foreman/settings/versions) for the next minor, unless the series is EOL. Be sure the version is set to sharing with subprojects.
+<% end -%>
+- [ ] Remove/change target version field for any open Redmine tickets assigned to the release still (next minor, unset it or reject)
 - [ ] Ensure that code in git matches issues fixed in <%= full_version %> in redmine. [issues.rb](https://gist.github.com/tbrisker/3320097f1d8c9abfb2dbcf8d8e216bba) can be used to generate a comparison between the two.
-<% unless is_rc %>- [ ] Change Redmine version <%= full_version %> state to Closed
-<% end %>
+<% unless is_rc -%>
+- [ ] Change Redmine version <%= full_version %> state to Closed
+<% end -%>
 
 # Tagging a release: <%= target_date %>
 
@@ -48,8 +53,10 @@
 
 - In foreman <%= short_version %>-stable:
   - [ ] Make sure [test_<%= short_version.tr('.', '_') %>_stable](https://ci.theforeman.org/job/test_<%= short_version.tr('.', '_') %>_stable/) is green
-<% if (is_rc || full_version.end_with?('0')) %>  - [ ] run `make -C locale tx-update`
-<% end %>  - [ ] Tag the release using [tag.sh](https://gist.github.com/tbrisker/d51cedea51ccbcca00e72c1fc61550fe) `tag.sh <%= full_version %> && git push upstream <%= short_version %>-stable --follow-tags`
+<% if (is_rc || full_version.end_with?('0')) -%>
+  - [ ] run `make -C locale tx-update`
+<% end -%>
+  - [ ] Tag the release using [tag.sh](https://gist.github.com/tbrisker/d51cedea51ccbcca00e72c1fc61550fe) `tag.sh <%= full_version %> && git push upstream <%= short_version %>-stable --follow-tags`
 - In smart-proxy <%= short_version %>-stable:
   - [ ] Make sure [test_proxy_<%= short_version.tr('.', '_') %>_stable](https://ci.theforeman.org/job/test_proxy_<%= short_version.tr('.', '_') %>_stable/) is green
   - [ ] Tag the release using [tag.sh](https://gist.github.com/tbrisker/d51cedea51ccbcca00e72c1fc61550fe) `tag.sh <%= full_version %> && git push upstream <%= short_version %>-stable --follow-tags`
@@ -109,15 +116,19 @@ Note: If for some reason there was an issue with the tarballs that required uplo
 
 # Release Owner
 
-<% unless is_rc %>- [ ] Update the versions on the website in [version](https://github.com/theforeman/theforeman.org/blob/gh-pages/_includes/version.html) and [latest news](https://github.com/theforeman/theforeman.org/blob/gh-pages/_includes/latest_news.html)
+<% unless is_rc -%>
+- [ ] Update the versions on the website in [version](https://github.com/theforeman/theforeman.org/blob/gh-pages/_includes/version.html) and [latest news](https://github.com/theforeman/theforeman.org/blob/gh-pages/_includes/latest_news.html)
 <% end -%>
-<% if is_rc && full_version.end_with?('1') %>- [ ] Add the <%= short_version %> in `foreman_versions` list in website's [`_config.yml`](https://github.com/theforeman/theforeman.org/blob/gh-pages/_config.yml) file
+<% if is_rc && full_version.end_with?('1') -%>
+- [ ] Add the <%= short_version %> in `foreman_versions` list in website's [`_config.yml`](https://github.com/theforeman/theforeman.org/blob/gh-pages/_config.yml) file
 <% end -%>
-<% if full_version.end_with?('0') %>- [ ] Update the `foreman_version` to <%= short_version %> in website's [`_config.yml`](https://github.com/theforeman/theforeman.org/blob/gh-pages/_config.yml) file
+<% if full_version.end_with?('.0') %>
+- [ ] Update the `foreman_version` to <%= short_version %> in website's [`_config.yml`](https://github.com/theforeman/theforeman.org/blob/gh-pages/_config.yml) file
 <% end -%>
 - [ ] Announce the release on [Discourse](https://community.theforeman.org/c/release-announcements/8)
 - [ ] Update the topic in #theforeman channel on Freenode
 - [ ] Share the release announcement on twitter
-<% if full_version.end_with?('0') %>- [ ] After about a week, update `stable` version in [foreman-infra](https://github.com/theforeman/foreman-infra/blob/master/puppet/modules/profiles/manifests/web.pp#L24)
+<% if full_version.end_with?('.0') %>
+- [ ] After about a week, update `stable` version in [foreman-infra](https://github.com/theforeman/foreman-infra/blob/master/puppet/modules/profiles/manifests/web.pp#L24)
 <% end -%>
 - [ ] Release pipeline will trigger [foreman-plugins-<%= short_version %>-deb-test-pipeline](https://ci.theforeman.org/job/foreman-plugins-<%= short_version %>-deb-test-pipeline/) and [foreman-plugins-<%= short_version %>-rpm-test-pipeline](https://ci.theforeman.org/job/foreman-plugins-<%= short_version %>-rpm-test-pipeline/). These don't block releases but can be used to understand known issues around plugin compatibility with Foreman <%= short_version %>.


### PR DESCRIPTION
This updates the ERB syntax to split over multiple lines. This is easier to read since there's less interpretation needed.