### PR TITLE
Swtich to centos7-updates

### DIFF
--- a/configs/foreman/1.20.yaml
+++ b/configs/foreman/1.20.yaml
@@ -37,7 +37,7 @@
     external_repos:
       - epel-7
       - puppetlabs-pc1-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: foreman-1.20-rhel7
     based_off: foreman-nightly-rhel7
@@ -57,7 +57,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: foreman-plugins-1.20-nonscl-rhel7
     based_off: foreman-plugins-nightly-nonscl-rhel7
@@ -76,7 +76,7 @@
         foreman-plugins-1.20-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - rhel-7.0-server-optional
   - name: foreman-plugins-1.20-rhel7
@@ -99,7 +99,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: foreman-1.20-rhel7-dist
     based_off: foreman-nightly-rhel7-dist
@@ -234,7 +234,7 @@
       - rhel-7.0-server
       - rhel-7.0-server-optional
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/1.21.yaml
+++ b/configs/foreman/1.21.yaml
@@ -37,7 +37,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet5-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: foreman-1.21-rhel7
     based_off: foreman-nightly-rhel7
@@ -57,7 +57,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: foreman-plugins-1.21-nonscl-rhel7
     based_off: foreman-plugins-nightly-nonscl-rhel7
@@ -76,7 +76,7 @@
         foreman-plugins-1.21-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: foreman-plugins-1.21-rhel7
     based_off: foreman-plugins-nightly-rhel7
@@ -98,7 +98,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: foreman-1.21-rhel7-dist
     based_off: foreman-nightly-rhel7-dist
@@ -231,7 +231,7 @@
       foreman-client-1.21-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/1.22.yaml
+++ b/configs/foreman/1.22.yaml
@@ -37,7 +37,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -90,7 +90,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -152,7 +152,7 @@
         foreman-plugins-1.22-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -209,7 +209,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -385,7 +385,7 @@
       foreman-client-1.22-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/1.23.yaml
+++ b/configs/foreman/1.23.yaml
@@ -37,7 +37,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -90,7 +90,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -152,7 +152,7 @@
         foreman-plugins-1.23-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -207,7 +207,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -383,7 +383,7 @@
       foreman-client-1.23-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/1.24.yaml
+++ b/configs/foreman/1.24.yaml
@@ -36,7 +36,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -89,7 +89,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -151,7 +151,7 @@
         foreman-plugins-1.24-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -206,7 +206,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -382,7 +382,7 @@
       foreman-client-1.24-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/2.0.yaml
+++ b/configs/foreman/2.0.yaml
@@ -34,7 +34,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -86,7 +86,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -146,7 +146,7 @@
         foreman-plugins-2.0-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -200,7 +200,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -374,7 +374,7 @@
       foreman-client-2.0-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/2.1.yaml
+++ b/configs/foreman/2.1.yaml
@@ -35,7 +35,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -87,7 +87,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet6-rhel-7
     build_groups:
@@ -204,7 +204,7 @@
         foreman-plugins-2.1-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -258,7 +258,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -541,7 +541,7 @@
       foreman-client-2.1-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/2.2.yaml
+++ b/configs/foreman/2.2.yaml
@@ -35,7 +35,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -87,7 +87,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet6-rhel-7
     build_groups:
@@ -204,7 +204,7 @@
         foreman-plugins-2.2-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -258,7 +258,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -541,7 +541,7 @@
       foreman-client-2.2-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/2.3.yaml
+++ b/configs/foreman/2.3.yaml
@@ -34,7 +34,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -86,7 +86,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet6-rhel-7
     build_groups:
@@ -203,7 +203,7 @@
         foreman-plugins-2.3-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -257,7 +257,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -488,7 +488,7 @@
       foreman-client-2.3-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/2.4.yaml
+++ b/configs/foreman/2.4.yaml
@@ -34,7 +34,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -86,7 +86,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet6-rhel-7
     build_groups:
@@ -203,7 +203,7 @@
         foreman-plugins-2.4-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -257,7 +257,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -488,7 +488,7 @@
       foreman-client-2.4-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/2.5.yaml
+++ b/configs/foreman/2.5.yaml
@@ -34,7 +34,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -86,7 +86,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet6-rhel-7
     build_groups:
@@ -204,7 +204,7 @@
         foreman-plugins-2.5-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -258,7 +258,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -490,7 +490,7 @@
       foreman-client-2.5-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/3.0.yaml
+++ b/configs/foreman/3.0.yaml
@@ -34,7 +34,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -86,7 +86,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet6-rhel-7
     build_groups:
@@ -204,7 +204,7 @@
         foreman-plugins-3.0-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -258,7 +258,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -439,7 +439,7 @@
       foreman-client-3.0-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/3.1.yaml
+++ b/configs/foreman/3.1.yaml
@@ -33,7 +33,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet6-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -85,7 +85,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet6-rhel-7
     build_groups:
@@ -203,7 +203,7 @@
         foreman-plugins-3.1-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -257,7 +257,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -438,7 +438,7 @@
       foreman-client-3.1-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/3.2.yaml
+++ b/configs/foreman/3.2.yaml
@@ -33,7 +33,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet7-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -85,7 +85,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet7-rhel-7
     build_groups:
@@ -201,7 +201,7 @@
         foreman-plugins-3.2-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -255,7 +255,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -434,7 +434,7 @@
       foreman-client-3.2-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/foreman/nightly.yaml
+++ b/configs/foreman/nightly.yaml
@@ -29,7 +29,7 @@
     external_repos:
       - epel-7
       - puppetlabs-puppet7-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -81,7 +81,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - puppetlabs-puppet7-rhel-7
     build_groups:
@@ -197,7 +197,7 @@
         foreman-plugins-nightly-nonscl-rhel7: 0
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -251,7 +251,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:
@@ -430,7 +430,7 @@
       foreman-client-nightly-rhel7: {}
     external_repos:
       - epel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
     build_groups:
       build:

--- a/configs/katello/3.10.yaml
+++ b/configs/katello/3.10.yaml
@@ -98,5 +98,5 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server

--- a/configs/katello/3.11.yaml
+++ b/configs/katello/3.11.yaml
@@ -86,5 +86,5 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server

--- a/configs/katello/3.12.yaml
+++ b/configs/katello/3.12.yaml
@@ -73,5 +73,5 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server

--- a/configs/katello/3.13.yaml
+++ b/configs/katello/3.13.yaml
@@ -73,5 +73,5 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server

--- a/configs/katello/3.14.yaml
+++ b/configs/katello/3.14.yaml
@@ -72,5 +72,5 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server

--- a/configs/katello/3.15.yaml
+++ b/configs/katello/3.15.yaml
@@ -64,7 +64,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-pulpcore-3.15-el7
     based_off: katello-pulpcore-nightly-el7

--- a/configs/katello/3.16.yaml
+++ b/configs/katello/3.16.yaml
@@ -94,7 +94,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-3.16-el8
     based_off: katello-nightly-el8

--- a/configs/katello/3.17.yaml
+++ b/configs/katello/3.17.yaml
@@ -76,7 +76,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-pulpcore-3.17-el7
     based_off: katello-pulpcore-nightly-el7

--- a/configs/katello/3.18.yaml
+++ b/configs/katello/3.18.yaml
@@ -103,7 +103,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-3.18-el8
     based_off: katello-nightly-el8

--- a/configs/katello/3.9.yaml
+++ b/configs/katello/3.9.yaml
@@ -89,5 +89,5 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server

--- a/configs/katello/4.0.yaml
+++ b/configs/katello/4.0.yaml
@@ -110,7 +110,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-4.0-el8
     based_off: katello-nightly-el8

--- a/configs/katello/4.1.yaml
+++ b/configs/katello/4.1.yaml
@@ -120,7 +120,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-4.1-el8
     based_off: katello-nightly-el8

--- a/configs/katello/4.2.yaml
+++ b/configs/katello/4.2.yaml
@@ -96,7 +96,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-4.2-el8
     based_off: katello-nightly-el8

--- a/configs/katello/4.3.yaml
+++ b/configs/katello/4.3.yaml
@@ -80,7 +80,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-4.3-el8
     based_off: katello-nightly-el8

--- a/configs/katello/4.4.yaml
+++ b/configs/katello/4.4.yaml
@@ -79,7 +79,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-4.4-el8
     based_off: katello-nightly-el8

--- a/configs/katello/nightly.yaml
+++ b/configs/katello/nightly.yaml
@@ -41,7 +41,7 @@
     external_repos:
       - epel-7
       - centos-sclo-rh-rhel-7
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
   - name: katello-nightly-el8
     based_off: null

--- a/configs/pulp/2.18.yaml
+++ b/configs/pulp/2.18.yaml
@@ -47,7 +47,7 @@
         pulp-2.18-rhel7: 0
       pulp-2.18-rhel7: {}
     external_repos:
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - epel-7
     build_groups:

--- a/configs/pulp/2.19.yaml
+++ b/configs/pulp/2.19.yaml
@@ -14,7 +14,7 @@
         pulp-2.19-rhel7: 0
       pulp-2.19-rhel7: {}
     external_repos:
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - epel-7
     build_groups:

--- a/configs/pulp/2.20.yaml
+++ b/configs/pulp/2.20.yaml
@@ -16,7 +16,7 @@
         pulp-2.20-rhel7: 0
       pulp-2.20-rhel7: {}
     external_repos:
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - epel-7
     build_groups:

--- a/configs/pulp/2.21.yaml
+++ b/configs/pulp/2.21.yaml
@@ -16,7 +16,7 @@
         pulp-2.21-rhel7: 0
       pulp-2.21-rhel7: {}
     external_repos:
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - epel-7
     build_groups:

--- a/configs/pulp/2.nightly.yaml
+++ b/configs/pulp/2.nightly.yaml
@@ -15,7 +15,7 @@
         pulp-nightly-rhel7: 0
       pulp-nightly-rhel7: {}
     external_repos:
-      - centos-7-server-updates
+      - centos7-updates
       - centos-7-server
       - epel-7
     build_groups:


### PR DESCRIPTION
centos-7-server-updates had a republish of the openscap rpm, causing an issue with a metadata hash mishmatch.  Based upon my research, this is not fixable for the external repo it happened in, due to the way koji stores its information.  The fix is to use a "new" external repo that points to that location