### PR TITLE
be more resilient when there are no groups in koji

### DIFF
--- a/lib/tool_belt/koji_tools.rb
+++ b/lib/tool_belt/koji_tools.rb
@@ -74,7 +74,7 @@ module ToolBelt
 
     def packages_for_group(tag, group)
       output, success = koji_info("list-groups #{tag} #{group}")
-      if success
+      if success && !output.nil?
         output.split("\n")[1..-1].map{|line| line.split(':')[0].strip}
       else
         []


### PR DESCRIPTION
sometimes, people delete tags to re-create them, but then
`koji list-groups` returns "nothing" and that confuses the code trying
to split it