### PR TITLE
correct katello 4.4 tag inheritance

### DIFF
--- a/configs/katello/4.4.yaml
+++ b/configs/katello/4.4.yaml
@@ -77,8 +77,8 @@
     inherits:
       katello-4.4-rhel7-build:
         katello-4.4-rhel7-override: 0
-        foreman-plugins-3.0-rhel7: 3
-        foreman-plugins-3.0-nonscl-rhel7: 4
+        foreman-plugins-3.2-rhel7: 3
+        foreman-plugins-3.2-nonscl-rhel7: 4
         foreman-3.2-rhel7: 5
         foreman-3.2-nonscl-rhel7: 6
       katello-4.4-rhel7-override:
@@ -102,7 +102,7 @@
     inherits:
       katello-4.4-el8-build:
         katello-4.4-el8-override: 0
-        foreman-plugins-3.0-el8: 3
+        foreman-plugins-3.2-el8: 3
         foreman-3.2-el8: 5
       katello-4.4-el8-override:
         katello-4.4-el8: 0


### PR DESCRIPTION
this is correct on koji, but not here in the config

seems has been forgotten to be commited