### PR TITLE
Update Transifex announcement URL

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -35,7 +35,7 @@
 - Translations:
   - [ ] Update locales in foreman __develop__: `make -C locale tx-update`
   - [ ] Ask plugin authors to start extracting i18n strings and pushing the changes into develop/master git branches so Transiflex can pick it up
-  - [ ] Announce string freeze date on discourse and send announcement via https://www.transifex.com/foreman/foreman/announcements/
+  - [ ] Announce string freeze date on Discourse and [send announcement](https://www.transifex.com/foreman/communication/?q=project%3Aforeman)
   - [ ] Update [foreman-dev](https://community.theforeman.org/c/development) with [translations status](https://www.transifex.com/projects/p/foreman/) to encourage 100% translations before release
 
 # Stabilization Week: <%= one_week_before %> to <%= one_week_before + 4 %>


### PR DESCRIPTION
The previous URL returns a 404 now.

The translation status link is also a 404, but I don't know what the replacement is.