### PR TITLE
Fix template syntax & provide ERB filename

### DIFF
--- a/lib/tool_belt/template.rb
+++ b/lib/tool_belt/template.rb
@@ -3,12 +3,10 @@ require 'ostruct'
 
 module ToolBelt
   module Template
-    def self.render(template, vars)
-      ERB.new(template, trim_mode: '-').result(OpenStruct.new(vars).instance_eval { binding })
-    end
-
     def self.render_file(filename, context)
-      self.render(File.read(filename), context)
+      erb = ERB.new(File.read(filename), trim_mode: '-')
+      erb.filename = File.expand_path(filename)
+      erb.result(OpenStruct.new(context).instance_eval { binding })
     end
   end
 end

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -122,7 +122,7 @@ Note: If for some reason there was an issue with the tarballs that required uplo
 
 # Release Owner
 
-<% if (is_rc full_version.end_with?('0')) -%>
+<% if (is_rc || full_version.end_with?('0')) -%>
 - [ ] Update installer options section using the [get-params script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/installer/get-params) (Note: this step can only be done after packages are released)
 <% end -%>
 <% unless is_rc -%>


### PR DESCRIPTION
If it fails to render, the filename becomes part of the stack trace. That makes it easier to find out where it failed.

Fixes: 5d85fa5e5171da66475efb3b13940432a1813b13