### PR TITLE
Move manual updates to after tagging

### DIFF
--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -8,40 +8,6 @@
 * Installer Maintainer: @
 <% end -%>
 
-# Manual updates: <%= target_date %>
-
-## Release Owner
-
-- [ ] Update manual if applicable for any additional installation steps
-- [ ] Update the [website's release notes section](https://github.com/theforeman/theforeman.org/tree/gh-pages/_includes/manuals/<%= short_version %>/1.2_release_notes.md) in the manual
-  - Using the [release notes script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/release_notes.rb): `./scripts/release_notes.rb foreman <%= version %>`
-  - Append CLI release notes taken from the [hammer-cli](https://github.com/theforeman/hammer-cli/blob/<%= short_version %>-stable/doc/release_notes.md) and [hammer-cli-foreman](https://github.com/theforeman/hammer-cli-foreman/blob/<%= short_version %>-stable/doc/release_notes.md) changelogs, in [theforeman.org](https://github.com/theforeman/theforeman.org/trees/gh-pages/_includes/manuals/<%= short_version %>/1.2_release_notes.md).
-<% if is_rc || is_first_ga -%>
-  - Headline features: half a dozen important features with a few sentences description each
-  - Upgrade warnings: all important notices that users must be aware of before upgrading
-  - Deprecations: anything that will be removed in a future release
-<% end -%>
-  - Submit this as a PR
-- [ ] Update [docs.theforeman.org](https://github.com/theforeman/foreman-documentation)
-  - Using [redmine_release_notes](https://github.com/theforeman/foreman-documentation/blob/<%= short_version %>/guides/doc-Release_Notes/redmine_release_notes) script (see [README](https://github.com/theforeman/foreman-documentation/blob/<%= short_version %>/guides/doc-Release_Notes/README.md) as well): `./guides/doc-Release_Notes/redmine_release_notes foreman <%= version %> > ./guides/doc-Release_Notes/topics/foreman-<%= version %>.adoc`
-  - Append CLI release notes taken from the [hammer-cli](https://github.com/theforeman/hammer-cli/blob/<%= short_version %>-stable/doc/release_notes.md) and [hammer-cli-foreman](https://github.com/theforeman/hammer-cli-foreman/blob/<%= short_version %>-stable/doc/release_notes.md) changelogs to [`foreman-<%= version %>.adoc`](https://github.com/theforeman/foreman-documentation/tree/<%= short_version %>/guides/doc-Release_Notes/topics/foreman-<%= version %>.adoc).
-<% if is_first_rc || (!is_rc && !is_first_ga) -%>
-  - Add `topics/foreman-<%= version %>.adoc` to `guides/doc-Release_Notes/master.adoc`: `sed -i '/x.y.z releases here/a include::topics/foreman-<%= version %>.adoc[leveloffset=+1]' guides/doc-Release_Notes/master.adoc`
-<% end -%>
-  - Make sure [foreman-contributors.adoc](https://github.com/theforeman/foreman-documentation/blob/<%= short_version %>/guides/doc-Release_Notes/topics/foreman-contributors.adoc) is updated
-  - Make sure headline features, upgrade warnings and deprecations are in sync with the website
-<% if is_first_ga -%>
-  - Update `web/content/index.adoc` and `web/content/js/versions.js` to declare <%= short_version %> as stable and <%= short_version_minus_two %> as unsupported
-<% elsif is_first_rc -%>
-  - Update `web/content/index.adoc` and `web/content/js/versions.js` to add <%= short_version %> as a release candidate
-<% end -%>
-  - Submit this as a PR
-<% if is_first_rc -%>
-- [ ] [Generate](https://github.com/theforeman/apidocs#adding-new-version) the apipie docs and raise pull request in [apidocs](https://github.com/theforeman/apidocs) repository
-<% else -%>
-- [ ] [Update](https://github.com/theforeman/apidocs#adding-new-version) the apipie docs and place those in the [foreman/<%= short_version %>/apidoc](https://github.com/theforeman/apidocs/tree/gh-pages/foreman/<%= short_version %>/apidoc) directory if any changes were made to the API
-<% end -%>
-
 # Preparing code: <%= target_date %>
 <% unless is_first_rc -%>
 
@@ -98,7 +64,7 @@ Note: If for some reason there was an issue with the tarballs that required uplo
 - Update [foreman-packaging](https://github.com/theforeman/foreman-packaging) branches
   - [ ] [rpm/<%= short_version %>](https://github.com/theforeman/theforeman-rel-eng/blob/master/bump_rpm_packaging)
   - [ ] [deb/<%= short_version %>](https://github.com/theforeman/theforeman-rel-eng/blob/master/bump_deb_packaging)
-- [ ] Wait for packages to be built using [wait_packaging](https://github.com/theforeman/theforeman-rel-eng/blob/master/wait_packaging) (checks [rpm/<%= short_version %>](https://ci.theforeman.org/job/foreman-packaging-rpm-<%= short_version %>-release/) and [deb/<%= short_version %>](https://ci.theforeman.org/job/foreman-packaging-deb-<%= short_version %>-release/))
+- [ ] Wait for packages to be built using [wait_packaging](https://github.com/theforeman/theforeman-rel-eng/blob/master/wait_packaging) (checks [rpm/<%= short_version %>](https://ci.theforeman.org/job/foreman-packaging-rpm-<%= short_version %>-release/) and [deb/<%= short_version %>](https://ci.theforeman.org/job/foreman-packaging-deb-<%= short_version %>-release/)). This takes a while so you can already start on the manual updates.
 - Check for outstanding PRs against <%= short_version %> packaging, and merge if possible:
   - [ ] [rpm/<%= short_version%>](https://github.com/theforeman/foreman-packaging/pulls?q=is%3Apr+is%3Aopen+base%3Arpm%2F<%= short_version %>)
   - [ ] [deb/<%= short_version%>](https://github.com/theforeman/foreman-packaging/pulls?q=is%3Apr+is%3Aopen+base%3Adeb%2F<%= short_version %>)
@@ -115,6 +81,40 @@ Note: If for some reason there was an issue with the tarballs that required uplo
 - [ ] Kick off the [release pipeline](https://ci.theforeman.org/job/foreman-<%= short_version %>-release-pipeline/) by calling [`release_pipeline`](https://github.com/theforeman/theforeman-rel-eng/blob/master/release_pipeline)
 - [ ] Kick off the [client pipeline](https://ci.theforeman.org/job/foreman-client-<%= short_version %>-rpm-pipeline/) by calling [`PROJECT=client release_pipeline`](https://github.com/theforeman/theforeman-rel-eng/blob/master/release_pipeline)
 - [ ] Kick off the [plugins pipeline](https://ci.theforeman.org/job/foreman-plugins-<%= short_version %>-rpm-pipeline/) by calling [plugins_pipeline](https://github.com/theforeman/theforeman-rel-eng/blob/master/plugins_pipeline)
+
+# Manual updates: <%= target_date %>
+
+## Release Owner
+
+- [ ] Update manual if applicable for any additional installation steps
+- [ ] Update the [website's release notes section](https://github.com/theforeman/theforeman.org/tree/gh-pages/_includes/manuals/<%= short_version %>/1.2_release_notes.md) in the manual
+  - Using the [release notes script](https://github.com/theforeman/theforeman.org/blob/gh-pages/scripts/release_notes.rb): `./scripts/release_notes.rb foreman <%= version %>`
+  - Append CLI release notes taken from the [hammer-cli](https://github.com/theforeman/hammer-cli/blob/<%= short_version %>-stable/doc/release_notes.md) and [hammer-cli-foreman](https://github.com/theforeman/hammer-cli-foreman/blob/<%= short_version %>-stable/doc/release_notes.md) changelogs, in [theforeman.org](https://github.com/theforeman/theforeman.org/trees/gh-pages/_includes/manuals/<%= short_version %>/1.2_release_notes.md).
+<% if is_rc || is_first_ga -%>
+  - Headline features: half a dozen important features with a few sentences description each
+  - Upgrade warnings: all important notices that users must be aware of before upgrading
+  - Deprecations: anything that will be removed in a future release
+<% end -%>
+  - Submit this as a PR
+- [ ] Update [docs.theforeman.org](https://github.com/theforeman/foreman-documentation)
+  - Using [redmine_release_notes](https://github.com/theforeman/foreman-documentation/blob/<%= short_version %>/guides/doc-Release_Notes/redmine_release_notes) script (see [README](https://github.com/theforeman/foreman-documentation/blob/<%= short_version %>/guides/doc-Release_Notes/README.md) as well): `./guides/doc-Release_Notes/redmine_release_notes foreman <%= version %> > ./guides/doc-Release_Notes/topics/foreman-<%= version %>.adoc`
+  - Append CLI release notes taken from the [hammer-cli](https://github.com/theforeman/hammer-cli/blob/<%= short_version %>-stable/doc/release_notes.md) and [hammer-cli-foreman](https://github.com/theforeman/hammer-cli-foreman/blob/<%= short_version %>-stable/doc/release_notes.md) changelogs to [`foreman-<%= version %>.adoc`](https://github.com/theforeman/foreman-documentation/tree/<%= short_version %>/guides/doc-Release_Notes/topics/foreman-<%= version %>.adoc).
+<% if is_first_rc || (!is_rc && !is_first_ga) -%>
+  - Add `topics/foreman-<%= version %>.adoc` to `guides/doc-Release_Notes/master.adoc`: `sed -i '/x.y.z releases here/a include::topics/foreman-<%= version %>.adoc[leveloffset=+1]' guides/doc-Release_Notes/master.adoc`
+<% end -%>
+  - Make sure [foreman-contributors.adoc](https://github.com/theforeman/foreman-documentation/blob/<%= short_version %>/guides/doc-Release_Notes/topics/foreman-contributors.adoc) is updated
+  - Make sure headline features, upgrade warnings and deprecations are in sync with the website
+<% if is_first_ga -%>
+  - Update `web/content/index.adoc` and `web/content/js/versions.js` to declare <%= short_version %> as stable and <%= short_version_minus_two %> as unsupported
+<% elsif is_first_rc -%>
+  - Update `web/content/index.adoc` and `web/content/js/versions.js` to add <%= short_version %> as a release candidate
+<% end -%>
+  - Submit this as a PR
+<% if is_first_rc -%>
+- [ ] [Generate](https://github.com/theforeman/apidocs#adding-new-version) the apipie docs and raise pull request in [apidocs](https://github.com/theforeman/apidocs) repository
+<% else -%>
+- [ ] [Update](https://github.com/theforeman/apidocs#adding-new-version) the apipie docs and place those in the [foreman/<%= short_version %>/apidoc](https://github.com/theforeman/apidocs/tree/gh-pages/foreman/<%= short_version %>/apidoc) directory if any changes were made to the API
+<% end -%>
 
 # After the packages have been released
 


### PR DESCRIPTION
The release notes are generated based on the content of Redmine. By moving the manual updates after closing the Redmine version you're guaranteed that the list of issues is in sync. Otherwise a change could still go in. The titles could still be changes, but there's no way to avoid that.

A hint is added that the optimal time to write is to wait while packaging is building.