### PR TITLE
Make procedure paths absolute

### DIFF
--- a/lib/tool_belt/commands/procedure.rb
+++ b/lib/tool_belt/commands/procedure.rb
@@ -105,7 +105,7 @@ module ToolBelt
       end
 
       def procedure_filename(project, procedure)
-        "procedures/#{project}/#{procedure}.md.erb"
+        File.join(__dir__, '..', '..', '..', 'procedures', project, "#{procedure}.md.erb")
       end
 
       def bump_last(version)


### PR DESCRIPTION
This allows calling the script from directories other than the tool_belt root.