### PR TITLE
Make the Foreman schedule post more descriptive

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -131,7 +131,7 @@ The next step should only be done after all branching, including packaging, has 
 
 ## Release Owner
 
-- [ ] Create release schedule page for next version (<%= develop %>) linked from [Development_Resources](https://projects.theforeman.org/projects/foreman/wiki/Development_Resources) and post planned schedule on Discourse.
+- [ ] Create a `Foreman <%= develop %> Schedule and Planning` post on [Development/Releases](https://community.theforeman.org/c/development/releases/20) using [schedule](https://github.com/theforeman/theforeman-rel-eng/blob/master/schedule)
 - Create Redmine versions
   - [ ] Add next version number (<%= develop %>.0) and make sure it is shared with subprojects in [foreman](https://projects.theforeman.org/projects/foreman/settings/versions)
   - [ ] Add first patch release (<%= release %>.1) and make sure it is shared with subprojects in [foreman](https://projects.theforeman.org/projects/foreman/settings/versions)


### PR DESCRIPTION
This gives the exact post title and where to place it. The release schedules are now posted to Discourse and no longer linked on the wiki.

Depends on https://github.com/theforeman/theforeman-rel-eng/pull/209