### PR TITLE
Add Katello 4.7.5 to config releases and fix some 4.7 releases

### DIFF
--- a/configs/katello/4.7.yaml
+++ b/configs/katello/4.7.yaml
@@ -2,17 +2,23 @@
 :project: katello
 :github_org: katello
 :releases:
+  :4.7.5:
+    :redmine_version_id: 1705
   :4.7.4:
-   :redmine_version_id: 1697
-:prior_releases:
+    :redmine_version_id: 1697
   :4.7.3:
-   :redmine_version_id: 1681
+    :redmine_version_id: 1681
   :4.7.2:
     :redmine_version_id: 1676
   :4.7.1:
     :redmine_version_id: 1646
   :4.7.0:
     :redmine_version_id: 1613
+:prior_releases:
+  :4.6.2:
+    :redmine_version_id: 1666
+  :4.6.1:
+    :redmine_version_id: 1636
   :4.6.0:
     :redmine_version_id: 1561
 :code_name: Whiskey Sour

--- a/configs/katello/4.8.yaml
+++ b/configs/katello/4.8.yaml
@@ -2,11 +2,21 @@
 :project: katello
 :github_org: katello
 :releases:
+  :4.8.1:
+    :redmine_version_id: 1688
   :4.8.0:
-   :redmine_version_id: 1623
+    :redmine_version_id: 1623
 :prior_releases:
+  :4.7.5:
+    :redmine_version_id: 1705
+  :4.7.4:
+    :redmine_version_id: 1697
+  :4.7.3:
+    :redmine_version_id: 1681
+  :4.7.2:
+    :redmine_version_id: 1676
   :4.7.1:
-   :redmine_version_id: 1646
+    :redmine_version_id: 1646
   :4.7.0:
     :redmine_version_id: 1613
 :code_name: Phoenix


### PR DESCRIPTION
I noticed that 4.7 had its own releases in the prior releases section, so I fixed it.