### PR TITLE
Move mo-files command usage to Katello release time

### DIFF
--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -21,7 +21,6 @@
   - [ ] `make -C locale tx-pull` in the katello directory
   - [ ] `grunt i18n:compile` in the katello/engines/bastion_katello directory
   - [ ] `bundle exec rake plugin:gettext[katello]` in the foreman directory
-  - [ ] `make -C locale mo-files` in the katello directory
   - [ ] Open a PR to Katello (no Redmine issue needed)
 
 # Three Weeks Prior to Branch Date

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -46,6 +46,7 @@
 - [ ] Once the PR is merged, perform the following in the Katello release branch (the real one, not your fork):
   - [ ] Tag: `git tag -s -m "Release <%= full_version %>" <%= full_version %>`
   - [ ] Push: `git push --follow-tags` (Must be pushed directly to the release branch, as pull request merges will not preserve tags.)
+  - [ ] Generate .mo translation files: `make -C locale mo-files` in the katello directory
   - [ ] Generate source gem: `gem build katello.gemspec`
   - [ ] Ensure you have a working login and password at rubygems.org
   - [ ] Push gem: `gem push katello-<%= full_version %>.gem`


### PR DESCRIPTION
The mo-files command used to commit to Git. We're now changing it to only generate the files. In the past, since the mo files are gitignored, that command was a no-op.

I'm also changing the procedure to use tx-update, which runs tx-pull and gives some more information.

Related Katello PR: https://github.com/Katello/katello/pull/10557