### PR TITLE
Add a help link to make a post a wiki

### DIFF
--- a/procedures/foreman/branch.md.erb
+++ b/procedures/foreman/branch.md.erb
@@ -1,4 +1,4 @@
-[ ] Make this post a wiki
+[ ] Make this post a wiki ([help](https://meta.discourse.org/t/create-a-wiki-post/30802))
 
 ## Roles
 

--- a/procedures/foreman/release.md.erb
+++ b/procedures/foreman/release.md.erb
@@ -1,4 +1,4 @@
-[ ] Make this post a wiki
+[ ] Make this post a wiki ([help](https://meta.discourse.org/t/create-a-wiki-post/30802))
 
 ## Roles
 

--- a/procedures/katello/branch.md.erb
+++ b/procedures/katello/branch.md.erb
@@ -1,4 +1,4 @@
-[ ] Make this post a wiki
+[ ] Make this post a wiki ([help](https://meta.discourse.org/t/create-a-wiki-post/30802))
 
 ## Roles
 

--- a/procedures/katello/release.md.erb
+++ b/procedures/katello/release.md.erb
@@ -1,4 +1,4 @@
-[ ] Make this post a wiki
+[ ] Make this post a wiki ([help](https://meta.discourse.org/t/create-a-wiki-post/30802))
 
 ## Roles
 


### PR DESCRIPTION
There was confusion about the process. Readers were assuming that checking off the checkbox made the post a wiki, but it's only a reminder to do so.