### PR TITLE
Add tool_belt config for Katello 4.15

### DIFF
--- a/configs/katello/4.15.yaml
+++ b/configs/katello/4.15.yaml
@@ -1,3 +1,17 @@
+---
+:project: katello
+:github_org: katello
+:nightly: false:releases:
+  :4.15.0:
+    :redmine_version_id: 1843
+:prior-releases:
+  :4.14.0:
+    :redmine_version_id: 1808
+  :4.13.1:
+    :redmine_version_id: 1857
+  :4.13.0:
+    :redmine_version_id: 1788
+:ignores:
 :repos:
   :katello:
     :main: true

--- a/configs/katello/4.15.yaml
+++ b/configs/katello/4.15.yaml
@@ -11,13 +11,13 @@
     :branch: 1.15.z
     :repo: https://github.com/Katello/hammer-cli-katello.git
   :katello-host-tools:
-    :branch: 4.5.0
+    :branch: 4.6.0
     :repo: https://github.com/Katello/katello-host-tools.git
   :katello-certs-tools:
     :branch: 2.10.0  
     :repo: https://github.com/Katello/katello-certs-tools.git
   :foreman_virt_who_configure:
-    :branch: 0.5.24
+    :branch: 0.5.25
     :repo: https://github.com/theforeman/foreman_virt_who_configure.git
   :smart_proxy_container_gateway:
     :branch: 3.1.0

--- a/configs/katello/4.15.yaml
+++ b/configs/katello/4.15.yaml
@@ -5,12 +5,12 @@
   :4.15.0:
     :redmine_version_id: 1843
 :prior-releases:
+  :4.14.1:
+    :redmine_version_id: 1878
   :4.14.0:
     :redmine_version_id: 1808
   :4.13.1:
     :redmine_version_id: 1857
-  :4.13.0:
-    :redmine_version_id: 1788
 :code_name: Macho Man
 :ignores:
 :repos:

--- a/configs/katello/4.15.yaml
+++ b/configs/katello/4.15.yaml
@@ -1,0 +1,27 @@
+:repos:
+  :katello:
+    :main: true
+    :branch: KATELLO-4.15
+    :repo: https://github.com/Katello/katello.git
+    :version_branch: true
+  :foreman-packaging:
+    :branch: rpm/3.13
+    :repo: https://github.com/theforeman/foreman-packaging.git
+  :hammer-cli-katello:
+    :branch: 1.15.z
+    :repo: https://github.com/Katello/hammer-cli-katello.git
+  :katello-host-tools:
+    :branch: 4.5.0
+    :repo: https://github.com/Katello/katello-host-tools.git
+  :katello-certs-tools:
+    :branch: 2.10.0  
+    :repo: https://github.com/Katello/katello-certs-tools.git
+  :foreman_virt_who_configure:
+    :branch: 0.5.24
+    :repo: https://github.com/theforeman/foreman_virt_who_configure.git
+  :smart_proxy_container_gateway:
+    :branch: 3.1.0
+    :repo: https://github.com/Katello/smart_proxy_container_gateway.git
+  :katello-selinux:
+    :branch: 5.0.2   
+    :repo: https://github.com/Katello/katello-selinux.git

--- a/configs/katello/4.15.yaml
+++ b/configs/katello/4.15.yaml
@@ -11,6 +11,7 @@
     :redmine_version_id: 1857
   :4.13.0:
     :redmine_version_id: 1788
+:code_name: Macho Man
 :ignores:
 :repos:
   :katello:


### PR DESCRIPTION
Config for 4.15 release. Notably katello-host-tools and foreman_virt_who_configure are needing to be released, @chris1984 is working on virt_who, and I'm looking for release help for katello-host-tools within phoenix.