### PR TITLE
Add 4.16.1 and 4.16.2 versions to config

### DIFF
--- a/configs/katello/4.16.yaml
+++ b/configs/katello/4.16.yaml
@@ -3,41 +3,45 @@
 :github_org: katello
 :nightly: false
 :releases:
-  :4.16.0:
-    :redmine_version_id: 1879
+    :4.16.2:
+        :redmine_version_id: 1958
+    :4.16.1:
+        :redmine_version_id: 1949
+    :4.16.0:
+        :redmine_version_id: 1879
 :prior-releases:
-  :4.15.1:
-    :redmine_version_id: 1915
-  :4.15.0:
-    :redmine_version_id: 1843
-  :4.14.3:
-    :redmine_version_id: 1935
+    :4.15.1:
+        :redmine_version_id: 1915
+    :4.15.0:
+        :redmine_version_id: 1843
+    :4.14.3:
+        :redmine_version_id: 1935
 :code_name: Taliesin
 :ignores:
 :repos:
-  :katello:
-    :main: true
-    :branch: KATELLO-4.16
-    :repo: https://github.com/Katello/katello.git
-    :version_branch: true
-  :foreman-packaging:
-    :branch: rpm/3.14
-    :repo: https://github.com/theforeman/foreman-packaging.git
-  :hammer-cli-katello:
-    :branch: 1.16.z
-    :repo: https://github.com/Katello/hammer-cli-katello.git
-  :katello-host-tools:
-    :branch: 4.6.0
-    :repo: https://github.com/Katello/katello-host-tools.git
-  :katello-certs-tools:
-    :branch: 2.10.0  
-    :repo: https://github.com/Katello/katello-certs-tools.git
-  :foreman_virt_who_configure:
-    :branch: 0.5.25
-    :repo: https://github.com/theforeman/foreman_virt_who_configure.git
-  :smart_proxy_container_gateway:
-    :branch: 3.2.0
-    :repo: https://github.com/Katello/smart_proxy_container_gateway.git
-  :katello-selinux:
-    :branch: 5.1.0 
-    :repo: https://github.com/Katello/katello-selinux.git
+    :katello:
+        :main: true
+        :branch: KATELLO-4.16
+        :repo: https://github.com/Katello/katello.git
+        :version_branch: true
+    :foreman-packaging:
+        :branch: rpm/3.14
+        :repo: https://github.com/theforeman/foreman-packaging.git
+    :hammer-cli-katello:
+        :branch: 1.16.z
+        :repo: https://github.com/Katello/hammer-cli-katello.git
+    :katello-host-tools:
+        :branch: 4.6.0
+        :repo: https://github.com/Katello/katello-host-tools.git
+    :katello-certs-tools:
+        :branch: 2.10.0
+        :repo: https://github.com/Katello/katello-certs-tools.git
+    :foreman_virt_who_configure:
+        :branch: 0.5.25
+        :repo: https://github.com/theforeman/foreman_virt_who_configure.git
+    :smart_proxy_container_gateway:
+        :branch: 3.2.0
+        :repo: https://github.com/Katello/smart_proxy_container_gateway.git
+    :katello-selinux:
+        :branch: 5.1.0
+        :repo: https://github.com/Katello/katello-selinux.git


### PR DESCRIPTION
Add 4.16.1 and 4.16.2 versions to config for 4.16.2 release work. I am aware that Zed changed the tab spacing but I tried for 10 minutes to fix and no longer care.