### PR TITLE
Fix cherry-pick tool missing z-stream commits

### DIFF
--- a/lib/tool_belt/issue_service.rb
+++ b/lib/tool_belt/issue_service.rb
@@ -9,7 +9,7 @@ module ToolBelt
       self.project_name = config.project
       self.release = config.release
       self.redmine_version_id = config.redmine_version_id
-      self.prior_releases = config.prior_releases || []
+      self.prior_releases = config.send(:"prior-releases") || []
       self.version_priors = config.releases.dig(:"#{release}", :prior_release) || []
     end
 


### PR DESCRIPTION
The cherry-pick tool was missing commits from z-stream releases because it couldn't properly access the prior-releases configuration from YAML files due to a hyphen/underscore mismatch. This fix enables the tool to correctly load z-stream issues from Redmine and include their commits in cherry-pick suggestions, ensuring that important fixes targeted for prior releases are properly suggested for cherry-picking to the current release.